### PR TITLE
Fix #4: Case mismatch of multiprotocol.h include

### DIFF
--- a/Multiprotocol/Multiprotocol.ino
+++ b/Multiprotocol/Multiprotocol.ino
@@ -23,7 +23,7 @@
 #include <avr/eeprom.h>
 #include <avr/pgmspace.h>
 #include <util/delay.h>
-#include "Multiprotocol.h"
+#include "multiprotocol.h"
 
 //Multiprotocol module configuration file
 #include "_Config.h"


### PR DESCRIPTION
Fix for https://github.com/pascallanger/DIY-Multiprotocol-TX-Module/issues/4