### PR TITLE
Note that the Hubsan has a hardcoded id. Also note that DEVO and DSM*…

### DIFF
--- a/Protocols_Details.md
+++ b/Protocols_Details.md
@@ -43,6 +43,7 @@ CH1|CH2|CH3|CH4|CH5|CH6|CH7|CH8|CH9
 ---|---|---|---|---|---|---|---|---
 A|E|T|R|FLIP|LIGHT|PICTURE|VIDEO|HEADLESS
 
+Only one model can be flown at the same time since the ID is hardcoded.
 ***
 #CC2500 RF Module
 

--- a/README.md
+++ b/README.md
@@ -92,10 +92,9 @@ Once the TX is telemetry enabled, it just needs to be configured on the model (s
 ##Protocols
 
 ###TX ID
-The multiprotocol TX module is using a 32bits ID generated randomly at first power up. This global ID is used by all protocols.
-There are little chances to get a duplicated ID.
+The multiprotocol TX module is using a 32bits ID generated randomly at first power up. This global ID is used by all protocolsexcept for the CYRF6963 (Devo, DSM2 and DSMX) protocols, which use the unique id of the CYRF6936 module. There are little chances to get a duplicated ID.
 
-It's possible to generate a new ID using bind button on the Hubsan protocol during power up.
+It's possible to generate a new ID using bind button on the Hubsan protocol during power up. 
 
 ###Bind
 To bind a model in PPM Mode press the physical bind button, apply power and then release.


### PR DESCRIPTION
… use the id of the radio module.

hubsan.ino has the id

```
 		//const uint32_t txid = 0xdb042679; 
```

Devo and DSM get their id by

```
CYRF_GetMfgData
```
