### PR TITLE
markdown syntax fixes

### DIFF
--- a/docs/Advanced_ATmega_Serial_Uploader.md
+++ b/docs/Advanced_ATmega_Serial_Uploader.md
@@ -1,4 +1,4 @@
-#ATmega Serial Uploader
+# ATmega Serial Uploader
 
 Mike Blandford adapted the optiboot bootloader for the 4-in-1 module to allow flashing of the module using a standard Arduino USB to serial adapter or FTDI adapter.  No need to open the module case. Once set up is very easy to use: 
 
@@ -22,7 +22,8 @@ While the bootloader is running, if it detects a communication problem, it confi
 
 This bootloader is for reading and writing the flash only, the EEPROM is not supported, neither is reading/writing the fuses, but it only uses 512 bytes of flash.
 
-##Install the bootloader
+## Install the bootloader
+
 To get the bootloader onto the ATmega you need to connect an flashing tool (like USBasp) to the 6-pin ISP connector on the board.
 Simply flash the .hex file to get the bootloader on the chip, and change the high fuse at the same time.
 

--- a/docs/Compiling.md
+++ b/docs/Compiling.md
@@ -4,7 +4,8 @@ Multiprotocol source are compiled using the well known Arduino IDE.
 
 The procedure below will guide you through all the steps to upload successfully a customized firmware.
 
-##Install the Arduino IDE and the Multiprotocol project firmware
+## Install the Arduino IDE and the Multiprotocol project firmware
+
 1. Download and install the Arduino IDE. The currently supported Arduino version is 1.6.12. available for [Windows]( https://www.arduino.cc/download_handler.php?f=/arduino-1.6.12-windows.exe) and [Mac OSX](https://www.arduino.cc/download_handler.php?f=/arduino-1.6.12-macosx.zip)
 1. It is recommended to upgrade Java to the [latest version](https://www.java.com/en/download/)
 1. Download the zip file with the Multiprotocol module source code from [here](https://github.com/pascallanger/DIY-Multiprotocol-TX-Module/archive/master.zip)
@@ -13,7 +14,8 @@ The procedure below will guide you through all the steps to upload successfully 
 
 ## Upload the firmware
 
-###Material you need to upload the firmware
+### Material you need to upload the firmware
+
 1. USBASP programmer supporting 3.3V: <img src="images/USBasp_Programmer.jpeg" width="200" height="200" /> [(example aliexpress link)](https://www.aliexpress.com/item/USBasp-USB-ISP-3-3V-5V-AVR-Programmer-USB-ATMEGA8-ATMEGA128-New-10PIN-Wire-Support/2036402518.html?spm=2114.30010308.8.10.jIbHzs). There are reports that some of the cheap programmers are not safe to use with 3.3V units, usually the black PCB versions are ok.
 1. 10pin to 6pin adapter: <img src="images/10pin_2_6pin.JPG" width="150" height="150" /> [(example ebay link)](http://www.ebay.fr/itm/10-Pin-a-6-Pin-Carte-Adaptateur-M-F-pour-AVRISP-USBASP-STK500-Noir-Bleu-WT-/291862396761?hash=item43f45abf59:g:gXsAAOSwMgdXyGnh)
 1. 6 pin header like this one: <img src="images/6pin_header.jpg" width="100" height="100" /> [(example Digi-Key link)](http://www.digikey.com/products/en?keywords=3M%20961206-6404-AR)
@@ -26,10 +28,10 @@ The 6 Pin header needs to be solder on the board like indicated by the red recta
 * Arduino Pro Mini module:
 <img src="images/ProMini_ISP.png" width="195" height="200" />
 
-###Connect the programmer
+### Connect the programmer
 
 1. Before you connect the programmer make sure that you have selected the 3.3V mode and not 5V. The RF Modules are not 5V tolerant and you will break them with 5V.  On most programmers this is done by moving a jumper.
-<img src="images/USBasp_Programmer_jumper.png" width="200" height="200" />
+     <img src="images/USBasp_Programmer_jumper.png" width="200" height="200" />
 1. Please re-read item 1. above before going on.
 1. Turn the rotary switch on the DIY Multiprotocol module to the 0 position. If you do not have a switch for Serial mode only then it is the same as being in the 0 position. The upload will not work if the switch is in any other position.
 1. Connect the 6-pin programming connector to the 6-pin ASP IVR connector on the DIY Multiprotocol board. Be sure to match the ground pin of the programmer connector to the ground pin on the board.
@@ -46,13 +48,16 @@ You are now ready to plug in the USB programmer to the computer
 
 If you are looking for a good working USBASP Windows driver, [use this one](http://www.protostack.com/download/USBasp-win-driver-x86-x64-v3.0.7.zip).
 
-###Configure Arduino IDE for Multiprotocol
+### Configure Arduino IDE for Multiprotocol
+
 1. Under Tools -> Board select the Arduino Pro or Pro Mini
 1. Under Tools -> Processor select the ATmega328 (5V, 16MHz)
 1. Under Tools -> Programmer select your programmer type (probably USBASP from the shopping list above)
 
 <a name="CustomizeFirmareToYourNeeds"></a>
-###Customize the firmware to match your hardware and your needs
+
+### Customize the firmware to match your hardware and your needs
+
 All customization is done by editing the ```_Config.h  ``` file in the Multiprotocol Arduino project.  
 
 In the Arduino IDE, click on the down arrow on the far right of the tab bar to show a list of project files (see the red circle on the screenshot below).  Scroll down and select the _Config.h file.
@@ -75,7 +80,7 @@ If you see something like the following, your firmware is still too big and you 
 
 If there is another error carefully read it, go to the line number indicated and correct your typo.
 
-###Flash the firmware
+### Flash the firmware
 
 1. If you have a 4in1 Multiprotocol module you can skip this step. If you've just finished to build your DIY Multiprotocol module (like v2.3d), the first step is to flash the fuses of the microcontroller. This needs to be done only once. For this purpose, click on **Tools -> Burn Bootloader** 
 
@@ -93,6 +98,7 @@ If you get an error that indicates a valid microcontroller was not found there i
  - your board
 
 <a name="AdvancedSettings"></a>
+
 ## Advanced settings
 
 So you followed the previous steps and your module is working.
@@ -101,9 +107,11 @@ Below are some extra steps which will:
  - Permit to flash even more protocols (extra 2KB)
 
 ### Arduino Boards.txt modification
+
 First, we need to append some text to the Arduino file boards.txt.
 
 #### On Windows
+
 1. Close the Arduino IDE
 1. Search Windows for the application WordPad (DO NOT USE Notepad). Right click on WordPad and select "Run as Administrator":
 <img src="images/WordPad_Admin.jpg" height="200" />
@@ -144,6 +152,7 @@ multi.menu.cpu.16MHzatmega328.build.f_cpu=16000000L
 ```
 
 #### On Mac OSX:
+
 1. Close the Arduino IDE
 1. Using finder navigate to ```Applications``` folder
 1. Ctl-Click on the Arduino application and select **Show Package Contents**.
@@ -151,6 +160,7 @@ multi.menu.cpu.16MHzatmega328.build.f_cpu=16000000L
 1. Copy and paste the "Multi 4-in-1" text listed above into the end of the file and save it.
 
 ### Burn Bootloader
+
 1. Open the Arduino IDE and load the Multiprotocol project.
 1. Select under **Tools -> Board** the new entry **Multi 4-in-1**
 1. Select under **Tools -> Programmer** the entry **USBasp**
@@ -158,6 +168,7 @@ multi.menu.cpu.16MHzatmega328.build.f_cpu=16000000L
 1. At this stage your flash module is empty so it's normal if the status LED does not do anything.
 
 ### Flash the firmware
+
 Scroll back to the section [Customize the firmware to your hardware and your needs](#CustomizeFirmareToYourNeeds) above and follow the instructions.
 
 You are done good fly!!!

--- a/docs/Models.md
+++ b/docs/Models.md
@@ -1,89 +1,112 @@
-#Model Setup
+# Model Setup
 This is the page to document model or receiver specific setup instructions.
 
 The Deviation project (on which this project was based) have a useful list of models [here](http://www.deviationtx.com/wiki/supported_models).
 
-#Syma X5C
+# Syma X5C
+
 <img src="http://img2.cheapdrone.co.uk/images/upload/2014/12/X5C%203/SKU115108-7.jpg" Width="200" Height="200" />
-##Channel Map
+
+## Channel Map
+
 CH1|CH2|CH3|CH4|CH5|CH6|CH7|CH8
 ---|---|---|---|---|---|---|---
 A|E|T|R|FLIP|RATES|PICTURE|VIDEO
-##Binding
-There are no special binding instructions.  The model powers up in Autobind mode and expects the bind sequence from the transmitter within the first 4-5 seconds. 
-##Tx Setup
-A basic 4-channel setup works perfectly, but some improvements are possible:   
-###Setting up a switch to Flip    
+
+## Binding
+
+There are no special binding instructions.  The model powers up in Autobind mode and expects the bind sequence from the transmitter within the first 4-5 seconds.
+
+## Tx Setup
+
+A basic 4-channel setup works perfectly, but some improvements are possible:
+
+### Setting up a switch to Flip
 
 1. Choose your "Rates" switch - typically the momentary TRN switch
 1. In the Mixer create an entry for CH5
-1. Edit this line as follows:  
+1. Edit this line as follows:
    - er9X: Source: sTRN, Weight 100 (or whatever switch you selected)
    - OpenTx: Source: SH, Weight 200 (or whatever switch you selected)
-   
-###Setting up a swich for high rates
+
+### Setting up a swich for high rates
 
 1. Choose your "Rates" switch
 1. In the Mixer create an entry for CH6
-1. Edit this line as follows:  
+1. Edit this line as follows:
    - er9X: Source: sTHR, Weight 100 (or whatever switch you selected)
    - OpenTx: Source: SF, Weight 200 (or whatever switch you selected)
 
-When the switch is in the rear position the rates will be standard, when the switch is forward rates will be high.  There is no need to move the throttle stick to the full up and full down position as with the standard controller. 
+When the switch is in the rear position the rates will be standard, when the switch is forward rates will be high.  There is no need to move the throttle stick to the full up and full down position as with the standard controller.
 
-###Setting up Idle-up
-One of the most annoying functions on the Syma X5C is that the motors stop when the throttle is pulled back.  This can be fixed by implmenting Idle-up on the transmitter (think of this as a very simple version of the Betaflight "Air Mode").  Idle up will ensure that even when the throttle is all the way down, a minimum command is passed to the motor to keep them spinning and to activate the stabilization.  
+### Setting up Idle-up
+One of the most annoying functions on the Syma X5C is that the motors stop when the throttle is pulled back.  This can be fixed by implmenting Idle-up on the transmitter (think of this as a very simple version of the Betaflight "Air Mode").  Idle up will ensure that even when the throttle is all the way down, a minimum command is passed to the motor to keep them spinning and to activate the stabilization.
 
-**To do this**:   
+**To do this**:
 
 1. Decide on a switch you will use to activate Idle up
 1. In the mixer menu add a line under Throttle and mix in a value of between 4 and 6 to be added to the throttle value if the switch is activated.  What this does is effectively prevents the throttle from going down to less than this value.
-1. When you want to fly in "idle-up" mode flick the switch and your stabilization will always be active.  
+1. When you want to fly in "idle-up" mode flick the switch and your stabilization will always be active.
 1. Remeber to switch off idle-up as soon as the quad lands (or crashes - to avoid damage to the motors)
 
-#Inductrix (Horizon Hobby)
+# Inductrix (Horizon Hobby)
 
 <img src="https://s7d5.scene7.com/is/image/horizonhobby/BLH8700_a0" Width="200" Height="200" />
 
-##Binding
+## Binding
+
 For telemetry enabled modules, you should just let the remote autodetect the settings. Otherwise choose DSMX 22ms with 6ch or 7ch. To bind the model, keep the transmitter off, power on the Inductrix. Wait until it flashes fast and then power up the Tx and use Bind.
 
-##Tx Setup
+## Tx Setup
+
 Remember that 100% on your transmitter using the MULTI-Module corresponds to 125% on the DSM receiver side.  On some functions sending 100% will confuse the model. Conversely 80% on your Tx is interpreted to be 100% at the model. Consider this when implementing the suggestions below.
-###Throttle
-For Inductrix FPV you might need to adjust the lower end of throttle to be a higher than default, otherwise motors will be spinning on minimal throttle.  One way to do this is to set the throttle to 80% output (100% of DSM output) and then to enable the **Throttle Idle Trim Only** under the Model Setup menu.  See image below:  
-<img src="images/Inductrix_Throttle_Setup.png" Width="600" Height="200" />  
-###Acro and Level Mode
+
+### Throttle
+
+For Inductrix FPV you might need to adjust the lower end of throttle to be a higher than default, otherwise motors will be spinning on minimal throttle.  One way to do this is to set the throttle to 80% output (100% of DSM output) and then to enable the **Throttle Idle Trim Only** under the Model Setup menu.  See image below:
+<img src="images/Inductrix_Throttle_Setup.png" Width="600" Height="200" />
+
+### Acro and Level Mode
+
 Setup channel 6 with a momemtary button or switch (e.g. SH on the Taranis) and use that switch to switch between modes. Set the output to somewhere between 40% to 60% for best results.
 
 An addition consideration when flying in Acro mode is to reduce stick sensitivity and to add some expo.  The screens below show one way of doing this.  Customize to your needs.
 
-####Inputs Screen   
+#### Inputs Screen
+
 The follwing INPUTS screen shows one potential setup to introduce expo for Acro mode.  The activation of the expo on Roll, Pitch and Yaw is when the SG switch is not in the back position.  Add to taste.
-<img src="images/Inductrix_Inputs.png" Width="600" Height="200" />  
+<img src="images/Inductrix_Inputs.png" Width="600" Height="200" />
 
-####Aileron Rates attached to Switch !SG-up
-The next screen shows and example of how the expo (50%) was set up on the stick input and how it is activated by !SG-up:  
-<img src="images/Inductrix_Aileron_Expo.png" Width="600" Height="200" />  
+#### Aileron Rates attached to Switch !SG-up
 
-####Mixer Menu
-The next screen shows the mixer menu with the mode change on momentary switch SH and High-Low rates on switch SC:  
-<img src="images/Inductrix_Mixer.png" Width="600" Height="200" />  
+The next screen shows and example of how the expo (50%) was set up on the stick input and how it is activated by !SG-up:
+<img src="images/Inductrix_Aileron_Expo.png" Width="600" Height="200" />
+
+#### Mixer Menu
+
+The next screen shows the mixer menu with the mode change on momentary switch SH and High-Low rates on switch SC:
+<img src="images/Inductrix_Mixer.png" Width="600" Height="200" />
 
 # Cheerson CX-20 / Quanum Nova
+
 <img src="http://uaequadcopters.com/images/products/Large/932-cheersoncx20dronquad.jpg" Width="200" Height="155" />
-##Channel Map
+
+## Channel Map
+
 CH1|CH2|CH3|CH4|CH5|CH6|CH7
 ---|---|---|---|---|---|---
 A|E|T|R|MODE|AUX1|AUX2
 
-##Binding
+## Binding
+
 The Rx powers up in binding mode so the transmitter should be set to autobind.  If the Tx signal is lost due to power-off or going out of range the Rx will not re-bind, and requires power-cycling before it will bind again.
 
-##Tx Setup
+## Tx Setup
+
 AETR are simple +100% mixes.  Note that the model expects Elevator (CH2) to be reversed, which is handled in the module firmware, so no need to reverse it on the Tx.
 
-###Flight modes
+### Flight modes
+
 CH5 is used to transmit the flight mode to the APM flight controller by setting the output to a value in a pre-defined range.  The original Tx uses a 3-pos switch (SWA) and a 2-pos switch (SWB) to achieve six different combinations, but only five are used - with SWA at 0, 1500 is sent when SWB is at 0 and 1, leaving flight mode 3 unused.  However, in the stock CX-20 flight controller settings, both flight mode 3 and 4 are set to the same flight mode, meaning we can configure our new Tx settings to send a value for mode 3 without changing the standard flight mode behaviour.  Afterwards, you can optionally use Mission Planner to assign a new flight mode to mode 3 or mode 4, or reconfigure them altogether.
 
 The values, modes, and switch positions for the stock Tx are:
@@ -113,7 +136,7 @@ One easy way to acheive this is to configure six logical switches mapped to two 
 
 To simply map the old Tx modes to the new Tx using the same switch positions, use the following configuration. The stock SWA switch is replaced with the ID0/1/2 switch, SWB is replaced with the AIL D/R switch.
 
-####Logical switches:
+#### Logical switches:
 
 Switch|Function|V1|V2
 ---|---|---|---
@@ -124,7 +147,7 @@ L. Switch 4|AND|ID0|AIL
 L. Switch 5|AND|ID1|AIL
 L. Switch 6|AND|ID1|!AIL
 
-####Flight modes (using CX-20 names):
+#### Flight modes (using CX-20 names):
 
 Mode|Name|Switch
 ---|---|---
@@ -135,7 +158,7 @@ Mode|Name|Switch
 5|DirLock|L5
 6|Stable|L6
 
-####Mixer setup:
+#### Mixer setup:
 
 Channel|Weight|Source|Switch|Multiplex
 ---|---|---|---|---
@@ -149,16 +172,17 @@ CH5|-80%|HALF|L1|REPLACE
 **NB** The weight values in this table will get you in the ball park, and will most likely work fine.  Because transmitters can vary they should be double-checked in the Mission Planer Radio Calibration screen, and tweaked as necessary.
 
 ### CH6 and CH7
+
 CH6 and CH7 can be assigned to switches or pots to provide additionaly functionality such as PID tuning, gimbal control, or APM auto-tune or auto-land.
 
 Replicating the stock setup of two pots, you would assign:
 
 Channel|Weight|Source|Multiplex
----|---|---|---|---
+---|---|---|---
 CH6|+100%|P1|ADD
 CH7|+100%|P3|ADD
 
-##Full Mixer Setup
+## Full Mixer Setup
 
 Channel|Source|Weight|Switch|Multiplex
 ---|---|---|---|---
@@ -176,5 +200,3 @@ CH6|+100%|P1|
 CH7|+100%|P3|
 
 Once you have configured the mixes you should connect Mission Planner to your CX-20 and use the Radio Calibration screen to verify that the channels are correctly assigned, and that the flight modes are correct.  Mission planner will give the exact PWM value on CH5, allowing the weights to be adjusted if needed.
-
-

--- a/docs/Module_BG_4-in-1.md
+++ b/docs/Module_BG_4-in-1.md
@@ -1,29 +1,32 @@
+# 4-in-1 module
 
-#4-in-1 module
 Currently the form factor of this module is designed for the JR-style module bay. Many of the popular RC transmitters use the JR-style module bay: FrSky Taranis, FlySky Th9x, Turnigy 9X/R/Pro
-##What you need
+
+## What you need
+
 A fully assembled module + case available from Banggood.com [here](http://www.banggood.com/CC2500-NRF24L01-A7105-CYRF693-4-In-1-RF-Module-With-Case-For-Futaba-JR-Frsky-Transmitter-p-1116892.html)
 
-<img src="images/4-in-1_Module_Case_BG.jpeg" width="221" height="200" /> 
+<img src="images/4-in-1_Module_Case_BG.jpeg" width="221" height="200" />
 
 Or
 
 The ready-made module available [here](http://www.banggood.com/2_4G-CC2500-A7105-Flysky-Frsky-Devo-DSM2-Multiprotocol-TX-Module-With-Antenna-p-1048377.html) or [here](http://www.gearbest.com/multi-rotor-parts/pp_554427.html)
 
 <img src="images/4-in-1_Module_BG.jpeg" width="200" height="200" />
- 
-Plus a module case that fits your module like the one [here](https://www.xtremepowersystems.net/proddetail.php?prod=XPS-J1CASE)  
- <img src="https://www.xtremepowersystems.net/prodimages/j1case.jpg" width="200" height="180" />  
-  or you can 3D print your own from a selection on Thingiverse ([Example 1](http://www.thingiverse.com/thing:1852868) [Example 2](http://www.thingiverse.com/thing:1661833)).  
+
+Plus a module case that fits your module like the one [here](https://www.xtremepowersystems.net/proddetail.php?prod=XPS-J1CASE)
+ <img src="https://www.xtremepowersystems.net/prodimages/j1case.jpg" width="200" height="180" />
+  or you can 3D print your own from a selection on Thingiverse ([Example 1](http://www.thingiverse.com/thing:1852868) [Example 2](http://www.thingiverse.com/thing:1661833)).
  [<img src="http://thingiverse-production-new.s3.amazonaws.com/renders/55/1c/cb/0a/e4/5d2c2b06be7f3f6f8f0ab4638dd7c6fc_preview_featured.jpg" width="250" height="200" /> ](http://www.thingiverse.com/thing:1852868)
 
 For 9XR/9XR Pro, a new 3D printed module is available which makes use of the built in antenna in the handle. This means nothing is getting out of the radio back! You can find all details of this module case on [Thingiverse](http://www.thingiverse.com/thing:2050717).
 
-<img src="images/9XR_module.jpg" width="113" height="200" /> <img src="images/9XR_module_connector.jpg" width="274" height="200" /> 
+<img src="images/9XR_module.jpg" width="113" height="200" /> <img src="images/9XR_module_connector.jpg" width="274" height="200" />
 
-##Different working modes
+## Different working modes
 
-###PPM mode
+### PPM mode
+
 If you are only planning on using the PPM interface with your transmitter, you need to connect it as described:
 
 <img src="images/PPM.png" width="574" height="340" />
@@ -34,39 +37,40 @@ The same plug is available on all versions of the module with the same signal lo
 
 If you wish to add an external device reading the telemetry, you need to enable serial mode as explained in the next topics otherwise you are now ready to go over to [Compiling and Programming](Compiling.md).
 
-###Serial mode
+### Serial mode
+
 If you have a transmitter that can support serial communication with the board then you need to wire up the board appropriately. There are three versions of the module and the steps are slightly different.
 
 Check which module you have and based on the pictures below.  If you purchased the module after June 2016 then it is likely that you have a V1.1 type module. If you have purchased the version with case it is likely that you have a V1.2 type module.
 
-#### **Version 1.2 (V1.2) type modules** 
+#### **Version 1.2 (V1.2) type modules**
 
 Serial is already enabled and ready to be used.
- 
+
 Written on PCB back JRFM_V1.2
 
-<img src="images/v1.2_ISP.jpg" width="340" height="340" /> 
+<img src="images/v1.2_ISP.jpg" width="340" height="340" />
 
 You are now ready to go over to [Compiling and Programming](Compiling.md).
 
-#### **Version 1.1 (V1.1) type modules** 
+#### **Version 1.1 (V1.1) type modules**
 
-Solder two bridges over the pads shown in the pictures below. 
- 
+Solder two bridges over the pads shown in the pictures below.
+
 V1.1a
 
-<img src="images/V2a_Serial_Enable.jpeg" width="300" height="340" /> 
-<img src="images/V2a_zoom_Serial_Enable.jpeg" width="450" height="340" /> 
+<img src="images/V2a_Serial_Enable.jpeg" width="300" height="340" />
+<img src="images/V2a_zoom_Serial_Enable.jpeg" width="450" height="340" />
 
 V1.1b
 
 Written on PCB back 1.2
 
-<img src="images/V2b_Serial_Enable.jpeg" width="220" height="340" /> 
+<img src="images/V2b_Serial_Enable.jpeg" width="220" height="340" />
 
 V1.1c
 
-<img src="images/V2c_Serial_Enable.jpeg" width="220" height="340" /> 
+<img src="images/V2c_Serial_Enable.jpeg" width="220" height="340" />
 
 You are now ready to go over to [Compiling and Programming](Compiling.md).
 
@@ -74,7 +78,7 @@ You are now ready to go over to [Compiling and Programming](Compiling.md).
 
 Solder bridges and resistors as illustrated in the picture below.
 
-<img src="images/V1_Serial_Enable.jpeg" width="360" height="340" /> 
+<img src="images/V1_Serial_Enable.jpeg" width="360" height="340" />
 
 If your module is always/sometime binding at power up without pressing the button replace the BIND led resistor (on the board back) of 1.2K by a 4.7K. Just to be safe it is recommended to do the modification anyway.
 

--- a/docs/Module_OrangeRx.md
+++ b/docs/Module_OrangeRx.md
@@ -1,4 +1,4 @@
-#OrangeRx Transmitter module
+# OrangeRx Transmitter module
 
 The OrangeRx transmitter module uses an Atmel XMega MCU.  This requires a PDI programmer to flash firmware, the USBASP programmers do not work. 
 

--- a/docs/PPM_Setup.md
+++ b/docs/PPM_Setup.md
@@ -1,9 +1,10 @@
-#PPM Setup
+# PPM Setup
 
 The Multiprotocol Module is compatible with any transmitter that is able to generate a PPM (Pulse Postion Modulation) output.  This includes all transmitters with a module bay or a trainer port.  It supports up to 16 channels from a PPM frame in the normal or inverted format (sometimes called positive or negative format in some transmitters).
 If you want the best performance you can set the number of channels and framerate corresponding to the number of channels of the specific receiver/model.
 
-##PPM Connections
+## PPM Connections
+
 If you do not have a module bay, there are only three wires you need to connect to get PPM to work.  (The pins are numbered from top to bottom) 
 - PPM on pin 1
 - vbat on pin 3
@@ -12,7 +13,7 @@ If you do not have a module bay, there are only three wires you need to connect 
 Note: vbat should be between 6V and 13V when using the 4-in-1 and 2.3 PCB boards. If you built a module from scratch it depends on the voltage regulator you chose.
 
 
-##Enabling PPM mode in your transmitter
+## Enabling PPM mode in your transmitter
 
 1. Enable the default Tx mode to be AETR. If you do not want to change the default channel order on your Tx you must remember to change the channel order for each new model using the module to AETR under the Model Mixer menu. (**This is really important - this is for all protocols - even for DSM as the MULTI-module firware will change the transmitted channel order according to the protocol.**)  
 1. The default PPM settings is 8 channels with a frame period of 22.5 ms (sometimes called the frame rate).  If you want to optimize performance you should change the channels to the actual number of channels required by your model.  The corresponding frame period should be set to (number of channels + 1) * 2.5 ms.  For example:
@@ -29,7 +30,7 @@ The default mapping of protocols to switch positions can be viewed on the Protoc
 
 The mapping of protocols to protocol selection switch positions can be changed in configuration settings as described on the [Compiling and Programming page](Compiling.md).
 
-##Binding in PPM mode
+## Binding in PPM mode
 
 In PPM mode follow the standard transmitter - receiver binding process: 
  1. Switch off the transmitter
@@ -41,7 +42,7 @@ In PPM mode follow the standard transmitter - receiver binding process:
 
 If you are having trouble binding to a consumer quad check the section below on [Getting your Bind Timing right](Bind_Timing.md). For more details on setting up specific receivers or models, check out the [Protocol Details page](Protocol_Details.md).
 
-##Telemetry in PPM mode
+## Telemetry in PPM mode
 
 Telemetry is available as a serial stream on the TX pin of the Atmega328p in the FrSky HUB format. The serial parameters are based on the protocol selected by the protocol selection dial. 
 

--- a/docs/Transmitters.md
+++ b/docs/Transmitters.md
@@ -1,39 +1,39 @@
 # Compatible Transmitters
 
-
 There are two different modes to interface the MULTI-Module and the transmitter: PPM and Serial. The considerations are different for each.
-- **PPM** is more generic, easy to implement and will work with most transmitters. 
+- **PPM** is more generic, easy to implement and will work with most transmitters.
 - **Serial** requires custom firmware on the transmitter but brings added functionality including protocol selection through the Tx interface and the option of telemetry (with the right transmitter firmware).
 
 Any Tx providing a PPM output (like a trainer port, or a transmitter with a RF module bay) is compatible with the MULTI-module.
 
-##PPM
+## PPM
+
 The DIY Mulitprotocol module supports industry standard PPM interface that works with all transmitters with either a module bay, and/or a trainer port.  Even the older 72MHz FM radios support this standard.
 
-<img src="images/PPM.png" width="338" height="200" /> 
+<img src="images/PPM.png" width="338" height="200" />
 
 The same module plug is available on all versions of the module with the same signal locations. Some radios have an open collector output (Futaba, Graupner...), in this case you should add a 4.7K resistor between PPM and BATT.
 
-When using the standard PPM Tx output, the protocol selection is achieved through a 16 position rotary switch on the module. This enables 15 (0=serial) protocol/sub-protocol/options combinations to be selected.  Binding is achieved by pressing a bind button on the back of the module (see picture below) 
+When using the standard PPM Tx output, the protocol selection is achieved through a 16 position rotary switch on the module. This enables 15 (0=serial) protocol/sub-protocol/options combinations to be selected.  Binding is achieved by pressing a bind button on the back of the module (see picture below)
 
 Since the module supports literally hundreds of protocol/sub-protocol/options combinations, you must select which of these will map to the 15 positions on the switch.  Refer to the [Compiling and Programming](Compiling.md) page for information on how to do his.
 
-Even in PPM mode it may still be possible to access telemetry information from selected receivers that support telemetry (e.g. Frsky, Hubsan, DSM).  To find out more about this advanced option check out the section on the [Advanced Topics](Advanced_Topics.md) page.  
+Even in PPM mode it may still be possible to access telemetry information from selected receivers that support telemetry (e.g. Frsky, Hubsan, DSM).  To find out more about this advanced option check out the section on the [Advanced Topics](Advanced_Topics.md) page.
 
 For transmitter setup using the PPM protocol go to the [PPM Setup page](PPM_Setup.md)
 
-##Serial
+## Serial
+
 Transmitters that run er9X, erSky9X or OpenTx firmwares (like the FrSky Taranis, FlySky TH9X and Turnigy 9X family of transmitters) have the option of using a fast serial communication protocol between the Tx and the DIY Multiprotocol module.  Using this serial communication protocol has some significant advantages:
 
-1. selecting the specific radio protocol (e.g. DSM) and the sub protocol (e.g. DSMX22) is done directly in the menu system of the Tx (see the picture below) 
-1. binding through the menu on the Tx 
-1. range checking through the menu on the Tx 
-1. in some cases enabling two-way serial communication for telemetry capable receivers/models. 
+1. selecting the specific radio protocol (e.g. DSM) and the sub protocol (e.g. DSMX22) is done directly in the menu system of the Tx (see the picture below)
+1. binding through the menu on the Tx
+1. range checking through the menu on the Tx
+1. in some cases enabling two-way serial communication for telemetry capable receivers/models.
 
-<img src="images/OpenTx_Multi_Menu.jpg" width="470" height="180" /> <img src="images/er9X_Multi_Menu.jpg" width="250" height="180" /> 
+<img src="images/OpenTx_Multi_Menu.jpg" width="470" height="180" /> <img src="images/er9X_Multi_Menu.jpg" width="250" height="180" />
 
-
-This serial protocol does not require any hardware modifications, but **will** require updating the firmware on your radio. Transmitters and firmware combinations that support the Serial protocol are shown in the table below. Also shown are telemetry considerations that will be discussed next.  
+This serial protocol does not require any hardware modifications, but **will** require updating the firmware on your radio. Transmitters and firmware combinations that support the Serial protocol are shown in the table below. Also shown are telemetry considerations that will be discussed next.
 
 Transmitter|Firmware Options|Telemetry Enabled
 :----------|:---------------|:----------------
@@ -49,28 +49,28 @@ Transmitter|Firmware Options|Telemetry Enabled
 
 Click on your transmitter above to view specific setup instructions.
 
+## Telemetry
 
-##Telemetry  
-
-To enable serial telemetry you need one of the radios and firmwares listed in the table above and **may** require modifications to your Tx. See the table above.  Before attempting telemetry check the following:  
+To enable serial telemetry you need one of the radios and firmwares listed in the table above and **may** require modifications to your Tx. See the table above.  Before attempting telemetry check the following:
 
 1. Your module has the appropriate connections or solder jumpers to connect the TX pin of the MCU to pin 5 on the module.  Check the documentation by selecting your module on this [page](Hardware.md) and reviewing the Telemetry section
 1. You have the correct firmware to allow serial communcation between the transmitter and the MULTI-Module.  Check the table above.
 1. Your transmitter hardware is telemetry enabled, or you have done the required mods.  Check the table above.
 
-<a name="Telemetry_Mod"></a>   
+<a name="Telemetry_Mod"></a>
 ##Optional Telemetry mod for 9X/R TH9X transmitters
-The telemetry mod for these transmitters has evolved.  The original and popular "FrSky Telemetry Mod" requires 2 pins on the transmitter module board to be modified (RX on pin 5 and TX on pin 2).  All the recent MULTI-Module hardware options supports serial transmission on pin 1 (the same pin as the PPM signal) so, in this case, only the mod on pin 5 is required. 
+The telemetry mod for these transmitters has evolved.  The original and popular "FrSky Telemetry Mod" requires 2 pins on the transmitter module board to be modified (RX on pin 5 and TX on pin 2).  All the recent MULTI-Module hardware options supports serial transmission on pin 1 (the same pin as the PPM signal) so, in this case, only the mod on pin 5 is required.
 
 A good tutorial to follow is Oscar Liang's [here](http://blog.oscarliang.net/turnigy-9x-advance-mod/) but when you get to wiring up the Tx Module bay pins, you only need to perform the steps relevant for Pin 5.
 
-You can see Midelic's original instructions [here](http://www.rcgroups.com/forums/showpost.php?p=28359305&postcount=2)  
+You can see Midelic's original instructions [here](http://www.rcgroups.com/forums/showpost.php?p=28359305&postcount=2)
 
 
-##Other Notes:  
-- er9X and erSky9X firmware already supports Multiprotocol Module as a standard feature.  The next major release of OpenTx - OpenTx 2.2 - will have DIY Mulitprotocol support as a standard feature.  
+## Other Notes:
 
-- Owners of Walkera Devo transmitters should look at the [Deviation-Tx](http://www.deviationtx.com) project for how to achieve the same end goal with your transmitters. 
+- er9X and erSky9X firmware already supports Multiprotocol Module as a standard feature.  The next major release of OpenTx - OpenTx 2.2 - will have DIY Mulitprotocol support as a standard feature.
+
+- Owners of Walkera Devo transmitters should look at the [Deviation-Tx](http://www.deviationtx.com) project for how to achieve the same end goal with your transmitters.
 
 - To enable telemetry on a Turnigy 9X or 9XR you need to modify your TX [read this.](#Telemetry_Mod).
 

--- a/docs/Tx-erSky9X.md
+++ b/docs/Tx-erSky9X.md
@@ -1,4 +1,5 @@
-#erSky9X family of transmitters
+# erSky9X family of transmitters
+
 This page is relevant to the following transmitters:  
  - Taranis running erSky9X (for the Taranis running OpenTx see [here](Tx-Taranis.md))
  - Turnigy 9XR Pro (for Turnigy 9X see [here](Tx-FlyskyTH9X.md))
@@ -10,18 +11,21 @@ This page is relevant to the following transmitters:
 
 
 ## Features
+
 The MULTI-Module can be used in this family of transmitters in either PPM mode or in Serial mode.  To operate in Serial mode, a version of erSky9X supporting the Multiprotocol Module must be installed on the Tx. 
 
 ## PPM Mode
+
 Please refer to the [PPM Setup](PPM_Setup.md) page. 
 
-
 ## Serial Mode
+
 Serial mode is only supported by the erSky9X firmware.  Loading this firmware is beyond the scope of this document but it is well covered in tutorial and video tutorials online. The firmware you should use with the MULTI-Module is available on Mike's [erSky9X Test Version Page](http://openrcforums.com/forum/viewtopic.php?f=7&t=4676).  Analyze the names of the different firmware options carefully - they contain all the information requried. (For example for the Taranis X9D Plus use the x9dp.bin firmware, etc.)
  
 erSky9X is well documented, the slightly outdated erSky9X documentation is [here](http://openrcforums.com/forum/viewtopic.php?f=5&t=6473#p90349).  You may find the new Er9x manual very helpful in understanding Ersky9x as the two firmwares are very closely related. It provides more detailed explanations and numerous relevant programming examples and is available [here](http://openrcforums.com/forum/viewtopic.php?f=5&t=6473#p90349).
 
-###Enabling Serial Mode
+### Enabling Serial Mode
+
 1. Confirm that the MULTI-Module has the required physical connections between the pins on the back of the Tx and the ATMega328 microprocessor.  This may require some soldering and depends on which version of the MULTI-Module you have.  Check out your module’s hardware page under the section **Enabling your module for Serial** for details. Click on the image that corresponds to your MULTI-Module on the [hardware](Hardware.md) page. 
 1. Plug in your MULTI-Module into the transmitter module bay.  If you have a rotary protocol selection switch, turn the switch to position 0 to put the unit into Serial mode.  
 1. Ensure throttle is down and all switches are in the start position and power up the Tx.  The red LED on the MULTI-Module should be flashing with a period of about 1 second indicating that it has not established a valid serial link with the Tx.  This is expected as we have not set up the Tx yet.
@@ -29,13 +33,15 @@ erSky9X is well documented, the slightly outdated erSky9X documentation is [here
 1. In the Model Setup menu scroll down to the **Protocol** submenu and change the RF settings to MULTI.  This should reveal a set of additional options (like Protocol and Options) 
 1. The red LED on the MULTI-Module should briefly flash and then remain solid.  This confirms that the MULTI-Module has established serial communication with the Tx.  If the red LED on the module continues to flash at a period of about 1 seconds then it signals that serial communication has not been established.  Check your settings under the model menu as described above and check that the protocol selection switch on the module is at 0 (enable Serial mode).  If there is still no communication, power down and power up the Tx.  Finally check that you have correctly enabled your module for serial as described on the hardware page for your module under the heading "Enabling your module for Serial". Click here to access the [hardware](Hardware.md) and then click on the picture of your module.
 
-###Protocol Selection in Serial mode
+### Protocol Selection in Serial mode
+
 To select the protocol:
  1. In the Model Setting menu, scroll through the available options under the MULTI protocol   
  1. Depending on which protocol you have selected you may be required to select a sup-protocol and options.  For example, there are three protocols that correspond to FrSky recievers: FrSky_V, FrSky_D and FrSky_X.  In some cases the sub-protocols have options that could specify the number of channels, packet frame rate or fine frequency tuning. Check out the [Protocol Details](Protocol_Details.md) page for detailed information and suggestions regarding the sub-protocols and options. The picture below shows the settings in the erSky Model Setup menu for FrSkyX subprotocol with {mike to insert} options:
  {mikeb to send simple picture}
 
-###Binding in Serial mode
+### Binding in Serial mode
+
 1. Switch on the model or put the receiver into bind mode 
 1. On the transmitter go to the Model Settings menu and scroll down to the [Bind] menu option and press Enter. 
 1. Press Enter again to exit Bind mode 
@@ -43,4 +49,3 @@ To select the protocol:
 For many consumer models consider checking the Autobind option.  This will initiate the bind sequence as soon as the module is powered up by the transmitter.
 
 If you are struggling to get a bind please see the [Getting the bind timing right page](Bind_Timing.md)
-


### PR DESCRIPTION
Several documents in the docs/ subdirectory had Markdown syntax errors that prevented the documents displaying correctly on github.  This isn't a comprehensive set of patches but it's a start.