### PR TITLE
Warn if CHECK_FOR_BOOTLOADER is enabled but a NO_BOOT board is selected

### DIFF
--- a/Multiprotocol/Validate.h
+++ b/Multiprotocol/Validate.h
@@ -18,12 +18,18 @@
 	#endif
 #endif
 
-//Change/Force configuration for the bootloader option
+// Automatically enable CHECK_FOR_BOOTLOADER if a FLASH_FROM_TX board is selected
 #if defined(ARDUINO_MULTI_FLASH_FROM_TX) || defined(ARDUINO_MULTI_STM32_FLASH_FROM_TX)
 	#define CHECK_FOR_BOOTLOADER
 #endif
-#if defined (ARDUINO_MULTI_NO_BOOT) || defined(ARDUINO_MULTI_STM32_NO_BOOT)
-	#undef CHECK_FOR_BOOTLOADER
+
+// Error if CHECK_FOR_BOOTLOADER is enabled but the 'Flash from TX' bootloader or upload method isn't selected.
+#if (defined(ARDUINO_MULTI_NO_BOOT) || defined(ARDUINO_MULTI_STM32_NO_BOOT)) && defined(CHECK_FOR_BOOTLOADER)
+  #if defined(STM32_BOARD)
+    #error "You have enabled CHECK_FOR_BOOTLOADER but not selected the 'Flash from TX' upload method."
+  #else
+    #error "You have enabled CHECK_FOR_BOOTLOADER but not selected the 'Flash from TX' bootloader."
+  #endif
 #endif
 
 //Change/Force configuration if OrangeTX

--- a/Multiprotocol/Validate.h
+++ b/Multiprotocol/Validate.h
@@ -18,9 +18,13 @@
 	#endif
 #endif
 
-// Automatically enable CHECK_FOR_BOOTLOADER if a FLASH_FROM_TX board is selected
-#if defined(ARDUINO_MULTI_FLASH_FROM_TX) || defined(ARDUINO_MULTI_STM32_FLASH_FROM_TX)
-	#define CHECK_FOR_BOOTLOADER
+// Error if CHECK_FOR_BOOTLOADER is not enabled but a FLASH_FROM_TX board is selected
+#if (defined(ARDUINO_MULTI_FLASH_FROM_TX) || defined(ARDUINO_MULTI_STM32_FLASH_FROM_TX)) &! defined(CHECK_FOR_BOOTLOADER)
+	#if defined(STM32_BOARD)
+    #error "You have selected the 'Flash from TX' upload method but not enabled CHECK_FOR_BOOTLOADER."
+  #else
+    #error "You have selected the 'Flash from TX' bootloader but not enabled CHECK_FOR_BOOTLOADER."
+  #endif
 #endif
 
 // Error if CHECK_FOR_BOOTLOADER is enabled but the 'Flash from TX' bootloader or upload method isn't selected.

--- a/Multiprotocol/_Config.h
+++ b/Multiprotocol/_Config.h
@@ -54,7 +54,7 @@
 /*************************/
 //Allow flashing multimodule directly with TX(erky9x or opentx modified firmwares)
 //Instructions: https://github.com/pascallanger/DIY-Multiprotocol-TX-Module/tree/master/BootLoaders#compiling--uploading-firmware-with-the-flash-from-tx-bootloader
-//To enable this feature remove the "//" on the next line. It is automatically enabled/disabled when you use the AVR Multi boards.
+//To enable this feature remove the "//" on the next line.  Requires a compatible bootloader or upload method to be selected when you use the Multi 4-in-1 Boards Manager definitions.
 //#define CHECK_FOR_BOOTLOADER
 
 /****************/


### PR DESCRIPTION
Rather than silently disabling CHECK_FOR_BOOTLOADER  lets throw an error prompting the user to make the correct selection.

This should prevent accidentally compiling firmware which doesn't have bootloader support.