### PR TITLE
Fix declarations for Hitec

### DIFF
--- a/Multiprotocol/Multiprotocol.ino
+++ b/Multiprotocol/Multiprotocol.ino
@@ -112,7 +112,7 @@ uint16_t state;
 uint8_t  len;
 uint8_t  armed, arm_flags, arm_channel_previous;
 
-#if defined(FRSKYX_CC2500_INO) || defined(SFHSS_CC2500_INO)
+#if defined(FRSKYX_CC2500_INO) || defined(SFHSS_CC2500_INO) || defined(HITEC_CC2500_INO)
 	uint8_t calData[48];
 #endif
 


### PR DESCRIPTION
The build fails due to a missing declaration for `calData` if Hitec is selected on its own.