### PR TITLE
Update Multiprotocol/E01X_nrf24l01.ino

### DIFF
--- a/Multiprotocol/E01X_nrf24l01.ino
+++ b/Multiprotocol/E01X_nrf24l01.ino
@@ -58,6 +58,9 @@
 #define E015_FLAG_EXPERT     0x02
 #define E015_FLAG_INTERMEDIATE 0x01
 
+// Bit vector from bit position
+#define BV(bit) (1 << bit)
+
 static void __attribute__((unused)) E015_check_arming()
 {
 	uint8_t arm_channel = E01X_ARM_SW;


### PR DESCRIPTION
E01X won't build unless CFLIE is also enabled because E01X uses a `BV` macro which is only defined in CFlie_nrf24l01.ino.