### PR TITLE
Correction in example file of #define Module_3

### DIFF
--- a/Multiprotocol/_MyConfig.h.example
+++ b/Multiprotocol/_MyConfig.h.example
@@ -9,7 +9,7 @@
 // For example you can also define multiple module configurations, uncomment the one you want to compile for:
 #define Module_1
 //#define Module_2
-//#define Module_2
+//#define Module_3
 //#define Module_4
 
 //Example on how to force the "Flash from TX" feature for all modules


### PR DESCRIPTION
This is a correction of a small error in the _MyConfig.h.example file listing #define Module_2 twice instead of #define Module_3

@pascallanger Also seeing if this can be merged into master from my repo?

Thanks - Rich