### PR TITLE
Add Table of Contents

### DIFF
--- a/Protocols_Details.md
+++ b/Protocols_Details.md
@@ -55,6 +55,58 @@ Notes:
 ## Serial mode
 Serial mode is selected by placing the rotary switch to position 0 before power on of the radio.
 
+# Available Protocol Table of Contents (Listed Alphabetically)
+
+Protocol Name|Protocol Number|Sub_Proto 0|Sub_Proto 1|Sub_Proto 2|Sub_Proto 3|Sub_Proto 4|Sub_Proto 5|Sub_Proto 6|Sub_Proto 7|RF Module
+---|---|---|---|---|---|---|---|---|---|---
+[Assan](Protocols_Details.md#ASSAN---24)|24|ASSAN||||||||NRF24L01
+[Bayang](Protocols_Details.md#BAYANG---14)|14|Bayang|H8S3D|X16_AH|IRDRONE|||||NRF24L01
+[Bugs](Protocols_Details.md#BUGS---41)|41|BUGS||||||||A7105
+[BugsMini](Protocols_Details.md#BUGSMINI---42)|42|BUGSMINI||||||||NRF24L01
+[Cabell](Protocols_Details.md#Cabell---34)|34|Cabell_V3|C_TELEM|-|-|-|-|F_SAFE|UNBIND|NRF24L01
+CFlie|38|CFlie||||||||NRF24L01
+[CG023](Protocols_Details.md#CG023---13)|13|CG023|YD829|||||||NRF24L01
+[Corona](Protocols_Details.md#CORONA---37)|37|COR_V1|COR_V2|FD_V3||||||CC2500
+[CX10](Protocols_Details.md#CX10---12)|12|GREEN|BLUE|DM007|-|J3015_1|J3015_2|MK33041||NRF24L01
+[Devo](Protocols_Details.md#DEVO---7)|7|Devo||||||||CYRF6936
+[DM002](Protocols_Details.md#DM002---33)|33|DM002||||||||NRF24L01
+[DSM](Protocols_Details.md#DSM---6)|6|DSM2-22|DSM2-11|DSMX-22|DSMX-11|AUTO||||CYRF6936
+[E01X](Protocols_Details.md#E01X---45)|45|E012|E015|||||||NRF24L01
+[ESky](Protocols_Details.md#ESKY---16)|16|ESky||||||||NRF24L01
+[ESky150](Protocols_Details.md#ESKY150---35)|35|ESKY150||||||||NRF24L01
+[Flysky](Protocols_Details.md#FLYSKY---1)|1|Flysky|V9x9|V6x6|V912|CX20||||A7105
+[Flysky AFHDS2A](Protocols_Details.md#FLYSKY-AFHDS2A---28)|28|PWM_IBUS|PPM_IBUS|PWM_SBUS|PPM_SBUS|||||A7105
+[FQ777](Protocols_Details.md#FQ777---23)|23|FQ777||||||||NRF24L01
+[FrskyD](Protocols_Details.md#FRSKYD---3)|3|FrskyD||||||||CC2500
+[FrskyV](Protocols_Details.md#FRSKYV---25)|25|FrskyV||||||||CC2500
+[FrskyX](Protocols_Details.md#FRSKYX---15)|15|CH_16|CH_8|EU_16|EU_8|||||CC2500
+[FY326](Protocols_Details.md#FY326---20)|20|FY326|FY319|||||||NRF24L01
+[GD00X](Protocols_Details.md#GD00X---47)|47|GD00X||||||||NRF24L01
+[GW008](Protocols_Details.md#GW008---32)|32|GW008||||||||NRF24L01
+[H8_3D](Protocols_Details.md#H8_3D---36)|36|H8_3D|H20H|H20Mini|H30Mini|||||NRF24L01
+[Hisky](Protocols_Details.md#HISKY---4)|4|Hisky|HK310|||||||NRF24L01
+[Hitec](Protocols_Details.md#HITEC---39)|39|OPT_FW|OPT_HUB|MINIMA||||||CC2500
+[Hontai](Protocols_Details.md#HONTAI---26)|26|HONTAI|JJRCX1|X5C1|FQ777_951|||||NRF24L01
+[Hubsan](Protocols_Details.md#HUBSAN---2)|2|H107|H301|H501||||||A7105
+[J6Pro](Protocols_Details.md#J6Pro---22)|22|J6PRO||||||||CYRF6936
+[KN](Protocols_Details.md#KN---9)|9|WLTOYS|FEILUN|||||||NRF24L01
+[MJXq](Protocols_Details.md#MJXQ---18)|18|WLH08|X600|X800|H26D|E010|H26WH|||NRF24L01
+[MT99xx](Protocols_Details.md#MT99XX---17)|17|MT|H7|YZ|LS|FY805||||NRF24L01
+[NCC1701](Protocols_Details.md#NCC1701---44)|44|NCC1701||||||||NRF24L01
+[OpenLRS](Protocols_Details.md#OpenLRS---27)|27|||||||||None
+[Q2X2](Protocols_Details.md#Q2X2---29)|29|Q222|Q242|Q282||||||NRF24L01
+[Q303](Protocols_Details.md#Q303---31)|31|Q303|CX35|CX10D|CX10WD|||||NRF24L01
+[SFHSS](Protocols_Details.md#SFHSS---21)|21|SFHSS||||||||CC2500
+[Shenqi](Protocols_Details.md#Shenqi---19)|19|Shenqi||||||||NRF24L01
+[SLT](Protocols_Details.md#SLT---11)|11|SLT_V1|SLT_V2|Q100|Q200|MR100||||NRF24L01
+[SymaX](Protocols_Details.md#Symax---10)|10|SYMAX|SYMAX5C|||||||NRF24L01
+Traxxas|43|Traxxas||||||||NRF24L01
+[V2x2](Protocols_Details.md#V2X2---5)|5|V2x2|JXD506|||||||NRF24L01
+[V911S](Protocols_Details.md#V911S---46)|46|V911S||||||||NRF24L01
+[WFly](Protocols_Details.md#WFLY---40)|40|WFLY||||||||CYRF6936
+[WK2x01](Protocols_Details.md#WK2X01---30)|30|WK2801|WK2401|W6_5_1|W6_6_1|W6_HEL|W6_HEL_I|||CYRF6936
+[YD717](Protocols_Details.md#YD717---8)|8|YD717|SKYWLKR|SYMAX4|XINXUN|NIHUI||||NRF24L01
+
 # A7105 RF Module
 
 ## FLYSKY - *1*
@@ -195,8 +247,9 @@ To bind V2 RXs you must follow the below procedure (original):
 ### Sub_protocol FD_V3 - *2*
 FlyDream RXs like IS-4R and IS-4R0
 
-## FRSKYV = FrSky 1 way - *25*
+## FRSKYV - *25*
 Models: FrSky receivers V8R4, V8R7 and V8FR.
+ - FrSkyV = FrSky 1 way
 
 Extended limits supported
 


### PR DESCRIPTION
This PR adds a Table of Contents chart for quick reference of all current available protocols with quick links to each protocols descriptive breakdown. 
Also makes navigating this lengthy file much easier.

@pascallanger  While researching for this project, there is no description breakdown for the CFlie protocol. I'm not sure how to describe it or I would have included it in this PR. 
Also I have included Traxxas in the TOC, although I know it is a future project and currently not available, but it is listed as Protocol 43 in the Multi.txt file

Thanks - Rich