### PR TITLE
Redpine changes

### DIFF
--- a/Multiprotocol/Redpine_cc2500.ino
+++ b/Multiprotocol/Redpine_cc2500.ino
@@ -98,47 +98,47 @@ static void REDPINE_data_frame() {
 
 static uint16_t ReadREDPINE()
 {
-    if ( prev_option != option )
-    { // Frequency adjust
-        CC2500_WriteReg(CC2500_0C_FSCTRL0, option);
-        prev_option = option ;
-    }
-    if(IS_BIND_IN_PROGRESS)
-    {
-        if(bind_counter == REDPINE_BIND)
-            REDPINE_init(0);
-        if(bind_counter == REDPINE_BIND/2)
-            REDPINE_init(1);
-        REDPINE_set_channel(49);
+	if ( prev_option != option )
+	{ // Frequency adjust
+		CC2500_WriteReg(CC2500_0C_FSCTRL0, option);
+		prev_option = option ;
+	}
+	if(IS_BIND_IN_PROGRESS)
+	{
+		if(bind_counter == REDPINE_BIND)
+			REDPINE_init(0);
+		if(bind_counter == REDPINE_BIND/2)
+			REDPINE_init(1);
+		REDPINE_set_channel(49);
         CC2500_SetTxRxMode(TX_EN);
-        CC2500_SetPower();
-        CC2500_Strobe(CC2500_SFRX);
-        REDPINE_build_bind_packet();
-        CC2500_Strobe(CC2500_SIDLE);
-        CC2500_WriteData(packet, REDPINE_PACKET_SIZE);
-        if(--bind_counter==0)
-        {
-            BIND_DONE;
-            REDPINE_init(sub_protocol);
-        }
-        return 9000;
-    }
-    else
-    {
-        CC2500_SetTxRxMode(TX_EN);
-        REDPINE_set_channel(hopping_frequency_no);
-        CC2500_SetPower();
-        CC2500_Strobe(CC2500_SFRX);
-        REDPINE_data_frame();
-        CC2500_Strobe(CC2500_SIDLE);
-        hopping_frequency_no = (hopping_frequency_no + 1) % 49;
-        CC2500_WriteData(packet, REDPINE_PACKET_SIZE);
-        if (sub_protocol==0)
-            return REDPINE_LOOPTIME_FAST*100;
-        else
-            return REDPINE_LOOPTIME_SLOW*1000;
-    }
-    return 1;
+		CC2500_SetPower();
+		CC2500_Strobe(CC2500_SFRX);
+		REDPINE_build_bind_packet();
+		CC2500_Strobe(CC2500_SIDLE);
+		CC2500_WriteData(packet, REDPINE_PACKET_SIZE);
+		if(--bind_counter==0)
+		{
+			BIND_DONE;
+			REDPINE_init(sub_protocol);
+		}
+		return 9000;
+	}
+	else
+	{
+		CC2500_SetTxRxMode(TX_EN);
+		REDPINE_set_channel(hopping_frequency_no);
+		CC2500_SetPower();
+		CC2500_Strobe(CC2500_SFRX);
+		REDPINE_data_frame();
+		CC2500_Strobe(CC2500_SIDLE);
+		hopping_frequency_no = (hopping_frequency_no + 1) % 49;
+		CC2500_WriteData(packet, REDPINE_PACKET_SIZE);
+		if (sub_protocol==0)
+			return REDPINE_LOOPTIME_FAST*100;
+		else
+			return REDPINE_LOOPTIME_SLOW*1000;
+	}
+	return 1;
 }
 
 // register, fast 250k, slow

--- a/Multiprotocol/Redpine_cc2500.ino
+++ b/Multiprotocol/Redpine_cc2500.ino
@@ -17,8 +17,8 @@
 
 #include "iface_cc2500.h"
 
-#define REDPINE_LOOPTIME_FAST 9		//9ms
-#define REDPINE_LOOPTIME_SLOW 22	//22ms
+#define REDPINE_LOOPTIME_FAST 25	//2.5ms
+#define REDPINE_LOOPTIME_SLOW 6  	//6ms
 
 #define REDPINE_BIND 1000
 #define REDPINE_PACKET_SIZE 11
@@ -98,46 +98,47 @@ static void REDPINE_data_frame() {
 
 static uint16_t ReadREDPINE()
 {
-	if ( prev_option != option )
-	{ // Frequency adjust
-		CC2500_WriteReg(CC2500_0C_FSCTRL0, option);
-		prev_option = option ;
-	}
-	if(IS_BIND_IN_PROGRESS)
-	{
-		if(bind_counter== REDPINE_BIND)
-			REDPINE_init(0);
-		if(state == REDPINE_BIND/2)
-			REDPINE_init(1);
-		REDPINE_set_channel(49);
-		CC2500_SetPower();
-		CC2500_Strobe(CC2500_SFRX);
-		REDPINE_build_bind_packet();
-		CC2500_Strobe(CC2500_SIDLE);
-		CC2500_WriteData(packet, REDPINE_PACKET_SIZE);
-		if(--bind_counter==0)
-		{
-			BIND_DONE;
-			REDPINE_init(sub_protocol);
-		}
-		return 9000;
-	}
-	else
-	{
-		CC2500_SetTxRxMode(TX_EN);
-		REDPINE_set_channel(hopping_frequency_no);
-		CC2500_SetPower();
-		CC2500_Strobe(CC2500_SFRX);
-		REDPINE_data_frame();
-		CC2500_Strobe(CC2500_SIDLE);
-		hopping_frequency_no = (hopping_frequency_no + 1) % 49;
-		CC2500_WriteData(packet, REDPINE_PACKET_SIZE);
-		if (sub_protocol==0)
-			return REDPINE_LOOPTIME_FAST*100;
-		else
-			return REDPINE_LOOPTIME_SLOW*100;
-	}
-	return 1;
+    if ( prev_option != option )
+    { // Frequency adjust
+        CC2500_WriteReg(CC2500_0C_FSCTRL0, option);
+        prev_option = option ;
+    }
+    if(IS_BIND_IN_PROGRESS)
+    {
+        if(bind_counter == REDPINE_BIND)
+            REDPINE_init(0);
+        if(bind_counter == REDPINE_BIND/2)
+            REDPINE_init(1);
+        REDPINE_set_channel(49);
+        CC2500_SetTxRxMode(TX_EN);
+        CC2500_SetPower();
+        CC2500_Strobe(CC2500_SFRX);
+        REDPINE_build_bind_packet();
+        CC2500_Strobe(CC2500_SIDLE);
+        CC2500_WriteData(packet, REDPINE_PACKET_SIZE);
+        if(--bind_counter==0)
+        {
+            BIND_DONE;
+            REDPINE_init(sub_protocol);
+        }
+        return 9000;
+    }
+    else
+    {
+        CC2500_SetTxRxMode(TX_EN);
+        REDPINE_set_channel(hopping_frequency_no);
+        CC2500_SetPower();
+        CC2500_Strobe(CC2500_SFRX);
+        REDPINE_data_frame();
+        CC2500_Strobe(CC2500_SIDLE);
+        hopping_frequency_no = (hopping_frequency_no + 1) % 49;
+        CC2500_WriteData(packet, REDPINE_PACKET_SIZE);
+        if (sub_protocol==0)
+            return REDPINE_LOOPTIME_FAST*100;
+        else
+            return REDPINE_LOOPTIME_SLOW*1000;
+    }
+    return 1;
 }
 
 // register, fast 250k, slow


### PR DESCRIPTION
Got it up and bound to a crazybeef3FR FC and matek411rx with these changes.  Thanks again Pascal!

Latency is better then frskyX with multiprotocol.  But about the same vs the internal xjt module running frskyX on a taranis.  Comparing opentx2.2 vs opentx2.3(some new heartbeat changes to lower latency)

Since I forgot to label my axis:  This is a histogram with ms on the X and counts on the Y.  Ran a test with 500 samples.
![image](https://user-images.githubusercontent.com/2583801/59813170-ca360680-92cd-11e9-8573-c5447d19f0e7.png)

I was hoping for a little more of an improvement. It looks like opentx is only updating the channel data periodicly and not on demand correct?

Here is a comparison vs deviationTX running Redpine - although there were some mods along the way to make the latency way better.

![image](https://user-images.githubusercontent.com/2583801/59813370-66600d80-92ce-11e9-9c91-2f2bfbe5181b.png)
