### PR TITLE
Added collectivepitch throttle channel swap option needed for JR

### DIFF
--- a/Multiprotocol/Common.ino
+++ b/Multiprotocol/Common.ino
@@ -70,7 +70,7 @@ uint8_t convert_channel_8b_limit_deadband(uint8_t num,uint8_t min,uint8_t mid, u
 	return val;
 }
 
-// Revert a channel and store it
+// Reverse a channel and store it
 void reverse_channel(uint8_t num)
 {
 	uint16_t val=2048-Channel_data[num];

--- a/Multiprotocol/Multiprotocol.h
+++ b/Multiprotocol/Multiprotocol.h
@@ -19,7 +19,7 @@
 #define VERSION_MAJOR		1
 #define VERSION_MINOR		2
 #define VERSION_REVISION	1
-#define VERSION_PATCH_LEVEL	67
+#define VERSION_PATCH_LEVEL	68
 
 //******************
 // Protocols
@@ -114,6 +114,15 @@ enum DSM
 	DSMX_22	= 2,
 	DSMX_11	= 3,
 	DSM_AUTO = 4,
+};
+enum DEVO
+{
+	DEVO_CH6	= 3,
+	DEVO_CH7	= 4,
+	DEVO_CH8	= 0,
+	DEVO_CH10	= 1,
+	DEVO_CH12	= 2,
+	DEVO_JR_HELI= 5,
 };
 enum YD717
 {       			
@@ -647,6 +656,13 @@ Serial: 100000 Baud 8e2      _ xxxx xxxx p --
 			DSMX_22 	2
 			DSMX_11 	3
 			DSM_AUTO	4
+		sub_protocol==DEVO
+			DEVO_CH6     3
+			DEVO_CH7     4
+			DEVO_CH8     0
+			DEVO_CH10    1
+			DEVO_CH12    2
+			DEVO_JR_HELI 5  // Specific JR HELI mode PPM output has collective on CH0 Throttle on CH5, the CAERxT 
 		sub_protocol==YD717
 			YD717		0
 			SKYWLKR		1

--- a/Multiprotocol/Multiprotocol.ino
+++ b/Multiprotocol/Multiprotocol.ino
@@ -135,6 +135,8 @@ const uint8_t CH_TAER[]={THROTTLE, AILERON, ELEVATOR, RUDDER, CH5, CH6, CH7, CH8
 const uint8_t CH_RETA[]={RUDDER, ELEVATOR, THROTTLE, AILERON, CH5, CH6, CH7, CH8, CH9, CH10, CH11, CH12, CH13, CH14, CH15, CH16};
 const uint8_t CH_EATR[]={ELEVATOR, AILERON, THROTTLE, RUDDER, CH5, CH6, CH7, CH8, CH9, CH10, CH11, CH12, CH13, CH14, CH15, CH16};
 
+const uint8_t CH_EATR_JR_HELI[]={2, 1, 5, 3, 4, 0, CH7, CH8, CH9, CH10, CH11, CH12, CH13, CH14, CH15, CH16};
+
 // Mode_select variables
 uint8_t mode_select;
 uint8_t protocol_flags=0,protocol_flags2=0;

--- a/Multiprotocol/TX_Def.h
+++ b/Multiprotocol/TX_Def.h
@@ -46,6 +46,24 @@
 #define CHANNEL_SWITCH		1104	// 1550us
 #define CHANNEL_MAX_COMMAND 1424	// 1750us
 
+//Fixed output definitions
+#define CH1   0
+#define CH2   1
+#define CH3   2
+#define CH4   3
+#define CH5   4
+#define CH6   5
+#define CH7   6
+#define CH8   7
+#define CH9   8
+#define CH10  9
+#define CH11  10
+#define CH12  11
+#define CH13  12
+#define CH14  13
+#define CH15  14
+#define CH16  15
+
 //Channel definitions
 #ifdef AETR
 	#define	AILERON  0
@@ -194,20 +212,3 @@
 	#define	THROTTLE 1
 	#define	RUDDER   0
 #endif
-
-#define	CH1		0
-#define	CH2		1
-#define	CH3		2
-#define	CH4		3
-#define	CH5		4
-#define	CH6		5
-#define	CH7		6
-#define	CH8		7
-#define	CH9		8
-#define	CH10	9
-#define	CH11	10
-#define	CH12	11
-#define	CH13	12
-#define	CH14	13
-#define	CH15	14
-#define	CH16	15

--- a/Multiprotocol/Validate.h
+++ b/Multiprotocol/Validate.h
@@ -18,7 +18,7 @@
 	#endif
 #endif
 
-// Check for minimum version of multi-module boards
+// Check for minimum board file definition version for DIY multi-module boards
 #define MIN_AVR_BOARD 107
 #define MIN_ORX_BOARD 107
 #define MIN_STM32_BOARD 114


### PR DESCRIPTION
As user I want to be able to use a DIY module in PPM use on a GRAUPNER/JR TX and be able to fly 3rd party protocol helis. For example on a MX22 when HELI model is chosen the channel ordering changes from TAER to CAERxT (where x is not in use per default). At the moment cannot be done with current state of code.

This pull now adds support for the Heli protocol DEVO for that is the most common scenario.

Note that issue with transmitter like this one **can not remap** channels of the PPM output. Trickery with mixing and 12c mix filling, will also not give a valid solution.

The PR will not change any past code behaviour. A specific _MyConfig.h will be needed to use it.

Other issues found while fixing this one are not in this PR, as to keep this PR simple. New fixes will get a separate PR.

The code is tested with a iRangeX Plus 4in1 module.