### PR TITLE
Added option for Pulsetrain remapping

### DIFF
--- a/Multiprotocol/Multiprotocol.h
+++ b/Multiprotocol/Multiprotocol.h
@@ -19,7 +19,7 @@
 #define VERSION_MAJOR		1
 #define VERSION_MINOR		2
 #define VERSION_REVISION	1
-#define VERSION_PATCH_LEVEL	74
+#define VERSION_PATCH_LEVEL	75
 
 //******************
 // Protocols
@@ -294,6 +294,9 @@ enum TRAXXAS
 #define AUTOBIND	1
 #define NO_AUTOBIND	0
 
+#define CO_DEFAULT 0
+#define CO_JR_HELI 1
+
 struct PPM_Parameters
 {
 	uint8_t protocol : 6;
@@ -302,6 +305,7 @@ struct PPM_Parameters
 	uint8_t power : 1;
 	uint8_t autobind : 1;
 	uint8_t option;
+	uint8_t channel_order : 2;
 };
 
 // Telemetry

--- a/Multiprotocol/_Config.h
+++ b/Multiprotocol/_Config.h
@@ -366,93 +366,93 @@
 const PPM_Parameters PPM_prot[14*NBR_BANKS]=	{
 #if NBR_BANKS > 0
 //******************************       BANK 1       ******************************
-//	Switch	Protocol 		Sub protocol	RX_Num	Power		Auto Bind		Option
-/*	1	*/	{PROTO_FLYSKY,	Flysky		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	2	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},	// RX number 0
-/*	3	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	1	,	P_HIGH	,	NO_AUTOBIND	,	0		},	// RX number 1
-/*	4	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	2	,	P_HIGH	,	NO_AUTOBIND	,	0		},	// RX number 2
-/*	5	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	3	,	P_HIGH	,	NO_AUTOBIND	,	0		},	// RX number 3
-/*	6	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	2	,	P_HIGH	,	NO_AUTOBIND	,	0		},	// RX number 4
-/*	7	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	3	,	P_HIGH	,	NO_AUTOBIND	,	0		},	// RX number 5
-/*	8	*/	{PROTO_SFHSS,	H107		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	9	*/	{PROTO_FRSKYV,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	40		},	// option=fine freq tuning
-/*	10	*/	{PROTO_FRSKYD,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	40		},	// option=fine freq tuning
-/*	11	*/	{PROTO_FRSKYX,	CH_16		,	0	,	P_HIGH	,	NO_AUTOBIND	,	40		},	// option=fine freq tuning
-/*	12	*/	{PROTO_FRSKYX,	EU_16		,	0	,	P_HIGH	,	NO_AUTOBIND	,	40		},	// option=fine freq tuning
-/*	13	*/	{PROTO_DEVO	,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	14	*/	{PROTO_WK2x01,	WK2801		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
+//	Switch		Protocol 	Sub protocol		RX_Num		Power		Auto Bind		Option		CH Order PPM out
+/*	1	*/	{PROTO_FLYSKY,	Flysky		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	2	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },	// RX number 0
+/*	3	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	1	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },	// RX number 1
+/*	4	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	2	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },	// RX number 2
+/*	5	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	3	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },	// RX number 3
+/*	6	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	2	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },	// RX number 4
+/*	7	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	3	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },	// RX number 5
+/*	8	*/	{PROTO_SFHSS,	H107		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	9	*/	{PROTO_FRSKYV,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	40		, CO_DEFAULT },	// option=fine freq tuning
+/*	10	*/	{PROTO_FRSKYD,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	40		, CO_DEFAULT },	// option=fine freq tuning
+/*	11	*/	{PROTO_FRSKYX,	CH_16		,	0	,	P_HIGH	,	NO_AUTOBIND	,	40		, CO_DEFAULT },	// option=fine freq tuning
+/*	12	*/	{PROTO_FRSKYX,	EU_16		,	0	,	P_HIGH	,	NO_AUTOBIND	,	40		, CO_DEFAULT },	// option=fine freq tuning
+/*	13	*/	{PROTO_DEVO,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	14	*/	{PROTO_WK2x01,	WK2801		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
 #endif
 #if NBR_BANKS > 1
 //******************************       BANK 2       ******************************
-//	Switch	Protocol 		Sub protocol	RX_Num	Power		Auto Bind		Option
-/*	1	*/	{PROTO_DSM	,	DSM2_11		,	0	,	P_HIGH	,	NO_AUTOBIND	,	6		},	// option=number of channels
-/*	2	*/	{PROTO_DSM	,	DSM2_22		,	0	,	P_HIGH	,	NO_AUTOBIND	,	6		},	// option=number of channels
-/*	3	*/	{PROTO_DSM	,	DSMX_11		,	0	,	P_HIGH	,	NO_AUTOBIND	,	6		},	// option=number of channels
-/*	4	*/	{PROTO_DSM	,	DSMX_22		,	0	,	P_HIGH	,	NO_AUTOBIND	,	6		},	// option=number of channels
-/*	5	*/	{PROTO_DSM	,	DSM2_11		,	0	,	P_HIGH	,	NO_AUTOBIND	,	8		},	// option=number of channels
-/*	6	*/	{PROTO_DSM	,	DSM2_22		,	0	,	P_HIGH	,	NO_AUTOBIND	,	8		},	// option=number of channels
-/*	7	*/	{PROTO_DSM	,	DSMX_11		,	0	,	P_HIGH	,	NO_AUTOBIND	,	8		},	// option=number of channels
-/*	8	*/	{PROTO_DSM	,	DSMX_22		,	0	,	P_HIGH	,	NO_AUTOBIND	,	8		},	// option=number of channels
-/*	9	*/	{PROTO_SLT	,	SLT_V1		,	0	,	P_HIGH	,	NO_AUTOBIND	,	6		},
-/*	10	*/	{PROTO_HUBSAN,	H107		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	11	*/	{PROTO_HUBSAN,	H301		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	12	*/	{PROTO_HUBSAN,	H501		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	13	*/	{PROTO_HISKY,	Hisky		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	14	*/	{PROTO_V2X2	,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
+//	Switch	Protocol 		Sub protocol		RX_Num		Power		Auto Bind		Option		CH Order PPM out
+/*	1	*/	{PROTO_DSM,	DSM2_11		,	0	,	P_HIGH	,	NO_AUTOBIND	,	6		, CO_DEFAULT },	// option=number of channels
+/*	2	*/	{PROTO_DSM,	DSM2_22		,	0	,	P_HIGH	,	NO_AUTOBIND	,	6		, CO_DEFAULT },	// option=number of channels
+/*	3	*/	{PROTO_DSM,	DSMX_11		,	0	,	P_HIGH	,	NO_AUTOBIND	,	6		, CO_DEFAULT },	// option=number of channels
+/*	4	*/	{PROTO_DSM,	DSMX_22		,	0	,	P_HIGH	,	NO_AUTOBIND	,	6		, CO_DEFAULT },	// option=number of channels
+/*	5	*/	{PROTO_DSM,	DSM2_11		,	0	,	P_HIGH	,	NO_AUTOBIND	,	8		, CO_DEFAULT },	// option=number of channels
+/*	6	*/	{PROTO_DSM,	DSM2_22		,	0	,	P_HIGH	,	NO_AUTOBIND	,	8		, CO_DEFAULT },	// option=number of channels
+/*	7	*/	{PROTO_DSM,	DSMX_11		,	0	,	P_HIGH	,	NO_AUTOBIND	,	8		, CO_DEFAULT },	// option=number of channels
+/*	8	*/	{PROTO_DSM,	DSMX_22		,	0	,	P_HIGH	,	NO_AUTOBIND	,	8		, CO_DEFAULT },	// option=number of channels
+/*	9	*/	{PROTO_SLT,	SLT_V1		,	0	,	P_HIGH	,	NO_AUTOBIND	,	6		, CO_DEFAULT },
+/*	10	*/	{PROTO_HUBSAN,	H107		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	11	*/	{PROTO_HUBSAN,	H301		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	12	*/	{PROTO_HUBSAN,	H501		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	13	*/	{PROTO_HISKY,	Hisky		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	14	*/	{PROTO_V2X2,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
 #endif
 #if NBR_BANKS > 2
 //******************************       BANK 3       ******************************
-//	Switch	Protocol 		Sub protocol	RX_Num	Power		Auto Bind		Option
-/*	1	*/	{PROTO_ESKY	,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	2	*/	{PROTO_ESKY150,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	3	*/	{PROTO_ASSAN,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	4	*/	{PROTO_CORONA,	COR_V2		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	5	*/	{PROTO_SYMAX,	SYMAX		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	6	*/	{PROTO_KN	,	WLTOYS		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	7	*/	{PROTO_BAYANG,	BAYANG		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	8	*/	{PROTO_BAYANG,	H8S3D		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	9	*/	{PROTO_BAYANG,	X16_AH		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	10	*/	{PROTO_BAYANG,	IRDRONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	11	*/	{PROTO_H8_3D,	H8_3D		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	12	*/	{PROTO_H8_3D,	H20H		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	13	*/	{PROTO_H8_3D,	H20MINI		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	14	*/	{PROTO_H8_3D,	H30MINI		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
+//	Switch		Protocol 	Sub protocol		RX_Num		Power		Auto Bind		Option		CH Order PPM out
+/*	1	*/	{PROTO_ESKY,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	2	*/	{PROTO_ESKY150,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	3	*/	{PROTO_ASSAN,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0	 	, CO_DEFAULT },
+/*	4	*/	{PROTO_CORONA,	COR_V2		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	5	*/	{PROTO_SYMAX,	SYMAX		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	6	*/	{PROTO_KN,	WLTOYS		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	7	*/	{PROTO_BAYANG,	BAYANG		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	8	*/	{PROTO_BAYANG,	H8S3D		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	9	*/	{PROTO_BAYANG,	X16_AH		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	10	*/	{PROTO_BAYANG,	IRDRONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	11	*/	{PROTO_H8_3D,	H8_3D		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	12	*/	{PROTO_H8_3D,	H20H		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	13	*/	{PROTO_H8_3D,	H20MINI		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	14	*/	{PROTO_H8_3D,	H30MINI		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
 #endif
 #if NBR_BANKS > 3
 //******************************       BANK 4       ******************************
-//	Switch	Protocol 		Sub protocol	RX_Num	Power		Auto Bind		Option
-/*	1	*/	{PROTO_MJXQ	,	WLH08		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	2	*/	{PROTO_MJXQ	,	X600		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	3	*/	{PROTO_MJXQ	,	X800		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	4	*/	{PROTO_MJXQ	,	H26D		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	5	*/	{PROTO_MJXQ	,	E010		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	6	*/	{PROTO_MJXQ	,	H26WH		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	7	*/	{PROTO_HONTAI,	HONTAI		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	8	*/	{PROTO_HONTAI,	JJRCX1		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	9	*/	{PROTO_HONTAI,	X5C1		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	10	*/	{PROTO_HONTAI,	FQ777_951	,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	11	*/	{PROTO_Q303	,	Q303		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	12	*/	{PROTO_Q303	,	CX35		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	13	*/	{PROTO_Q303	,	CX10D		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	14	*/	{PROTO_Q303	,	CX10WD		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
+//	Switch	Protocol 		Sub protocol		RX_Num		Power		Auto Bind		Option		CH Order PPM out
+/*	1	*/	{PROTO_MJXQ,	WLH08		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	2	*/	{PROTO_MJXQ,	X600		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	3	*/	{PROTO_MJXQ,	X800		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	4	*/	{PROTO_MJXQ,	H26D		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	5	*/	{PROTO_MJXQ,	E010		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	6	*/	{PROTO_MJXQ,	H26WH		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	7	*/	{PROTO_HONTAI,	HONTAI		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	8	*/	{PROTO_HONTAI,	JJRCX1		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	9	*/	{PROTO_HONTAI,	X5C1		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	10	*/	{PROTO_HONTAI,	FQ777_951	,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	11	*/	{PROTO_Q303,	Q303		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	12	*/	{PROTO_Q303,	CX35		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	13	*/	{PROTO_Q303,	CX10D		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	14	*/	{PROTO_Q303,	CX10WD		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
 #endif
 #if NBR_BANKS > 4
 //******************************       BANK 5       ******************************
-//	Switch	Protocol 		Sub protocol	RX_Num	Power		Auto Bind		Option
-/*	1	*/	{PROTO_CX10	,	CX10_GREEN	,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	2	*/	{PROTO_CX10	,	CX10_BLUE	,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	3	*/	{PROTO_CX10	,	DM007		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	4	*/	{PROTO_CX10	,	JC3015_1	,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	5	*/	{PROTO_CX10	,	JC3015_2	,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	6	*/	{PROTO_CX10	,	MK33041		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	7	*/	{PROTO_Q2X2	,	Q222		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	8	*/	{PROTO_Q2X2	,	Q242		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	9	*/	{PROTO_Q2X2	,	Q282		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	10	*/	{PROTO_CG023,	CG023		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	11	*/	{PROTO_CG023,	YD829		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	12	*/	{PROTO_FQ777,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	13	*/	{PROTO_YD717,	YD717		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	14	*/	{PROTO_MT99XX,	MT99		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
+//	Switch		Protocol 	Sub protocol		RX_Num		Power		Auto Bind		Option		CH Order PPM out
+/*	1	*/	{PROTO_CX10,	CX10_GREEN	,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	2	*/	{PROTO_CX10,	CX10_BLUE	,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	3	*/	{PROTO_CX10,	DM007		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	4	*/	{PROTO_CX10,	JC3015_1	,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	5	*/	{PROTO_CX10,	JC3015_2	,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	6	*/	{PROTO_CX10,	MK33041		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	7	*/	{PROTO_Q2X2,	Q222		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	8	*/	{PROTO_Q2X2,	Q242		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	9	*/	{PROTO_Q2X2,	Q282		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	10	*/	{PROTO_CG023,	CG023		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	11	*/	{PROTO_CG023,	YD829		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	12	*/	{PROTO_FQ777,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	13	*/	{PROTO_YD717,	YD717		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	14	*/	{PROTO_MT99XX,	MT99		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
 #endif
 };
 // RX_Num is used for TX & RX match. Using different RX_Num values for each receiver will prevent starting a model with the false config loaded...
@@ -469,6 +469,8 @@ const PPM_Parameters PPM_prot[14*NBR_BANKS]=	{
 // Option: the value is between -128 and +127.
 // The option value is only valid for some protocols, read this page for more information: https://github.com/pascallanger/DIY-Multiprotocol-TX-Module/blob/master/Protocols_Details.md
 
+// CH Order PPM out  CO_DEFAULT or CO_JR_HELI where the latter one has Collective CHannel swapped with Throttle on Heli model modes for TX's that have non variable output pulsetrain
+ 
 /* Available protocols and associated sub protocols to pick and choose from (Listed in alphabetical order)
 	PROTO_AFHDS2A
 		PWM_IBUS

--- a/Multiprotocol/_MyConfig.h.example
+++ b/Multiprotocol/_MyConfig.h.example
@@ -60,20 +60,20 @@
 	#define MY_PPM_PROT		// Use the bellow protocol list
 	const PPM_Parameters My_PPM_prot[14*NBR_BANKS]={
 //******************************       BANK 1       ******************************
-//	Switch	Protocol 		Sub protocol	RX_Num	Power		Auto Bind		Option
-/*	1	*/	{PROTO_KN	,	WLTOYS		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	2	*/	{PROTO_FLYSKY,	Flysky		,	0	,	P_HIGH	,	AUTOBIND	,	0		},
-/*	3	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	1	,	P_HIGH	,	NO_AUTOBIND	,	0		},	// RX number 1
-/*	4	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	2	,	P_HIGH	,	NO_AUTOBIND	,	0		},	// RX number 2
-/*	5	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	3	,	P_HIGH	,	NO_AUTOBIND	,	0		},	// RX number 3
-/*	6	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	2	,	P_HIGH	,	NO_AUTOBIND	,	0		},	// RX number 4
-/*	7	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	3	,	P_HIGH	,	NO_AUTOBIND	,	0		},	// RX number 5
-/*	8	*/	{PROTO_SFHSS,	H107		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	9	*/	{PROTO_FRSKYV,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	40		},	// option=fine freq tuning
-/*	10	*/	{PROTO_FRSKYD,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	40		},	// option=fine freq tuning
-/*	11	*/	{PROTO_FRSKYX,	CH_16		,	0	,	P_HIGH	,	NO_AUTOBIND	,	40		},	// option=fine freq tuning
-/*	12	*/	{PROTO_FRSKYX,	EU_16		,	0	,	P_HIGH	,	NO_AUTOBIND	,	40		},	// option=fine freq tuning
-/*	13	*/	{PROTO_DEVO	,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
-/*	14	*/	{PROTO_WK2x01,	WK2801		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		},
+//	Switch	Protocol 		Sub protocol		RX_Num		Power		Auto Bind		Option		CH Order PPM out 
+/*	1	*/	{PROTO_KN,	WLTOYS		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	2	*/	{PROTO_FLYSKY,	Flysky		,	0	,	P_HIGH	,	AUTOBIND	,	0		, CO_DEFAULT },
+/*	3	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	1	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },	// RX number 1
+/*	4	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	2	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },	// RX number 2
+/*	5	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	3	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },	// RX number 3
+/*	6	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	2	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },	// RX number 4
+/*	7	*/	{PROTO_AFHDS2A,	PWM_IBUS	,	3	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },	// RX number 5
+/*	8	*/	{PROTO_SFHSS,	H107		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	9	*/	{PROTO_FRSKYV,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	40		, CO_DEFAULT },	// option=fine freq tuning
+/*	10	*/	{PROTO_FRSKYD,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	40		, CO_DEFAULT },	// option=fine freq tuning
+/*	11	*/	{PROTO_FRSKYX,	CH_16		,	0	,	P_HIGH	,	NO_AUTOBIND	,	40		, CO_DEFAULT },	// option=fine freq tuning
+/*	12	*/	{PROTO_FRSKYX,	EU_16		,	0	,	P_HIGH	,	NO_AUTOBIND	,	40		, CO_DEFAULT },	// option=fine freq tuning
+/*	13	*/	{PROTO_DEVO,	NONE		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_DEFAULT },
+/*	14	*/	{PROTO_WK2x01,	WK2801		,	0	,	P_HIGH	,	NO_AUTOBIND	,	0		, CO_JR_HELI },
 	};
 #endif


### PR DESCRIPTION
Adding remapping of channels redux...

As user I want to be able to use a DIY module in PPM use on a GRAUPNER/JR TX and be able to fly 3rd party protocol helis. For example on a MX22 when HELI model is chosen the channel ordering changes from TAER to CAERxT (where x is not in use per default). At the moment cannot be done with current state of code.

This pull now adds support for the Heli protocol DEVO for that is the most common scenario.

Note that issue with transmitter like this one can not remap channels of the PPM output. Trickery with mixing and 12c mix filling, will also not give a valid solution.

The PR will not change any past code behaviour. A specific _MyConfig.h will be needed to use it.

Other issues found while fixing this one are not in this PR, as to keep this PR simple. New fixes will get a separate PR.

The code is tested with a iRangeX Plus 4in1 module.


