### PR TITLE
Disable scanner telemetry when scanner protocol is disabled

### DIFF
--- a/Multiprotocol/Validate.h
+++ b/Multiprotocol/Validate.h
@@ -293,6 +293,9 @@
 	#if not defined(DSM_CYRF6936_INO)
 		#undef DSM_TELEMETRY
 	#endif
+	#if not defined(SCANNER_CC2500_INO)
+		#undef SCANNER_TELEMETRY
+	#endif
 	#if not defined(DSM_TELEMETRY) && not defined(SPORT_TELEMETRY) && not defined(HUB_TELEMETRY) && not defined(HUBSAN_HUB_TELEMETRY) && not defined(BUGS_HUB_TELEMETRY) && not defined(NCC1701_HUB_TELEMETRY) && not defined(BAYANG_HUB_TELEMETRY) && not defined(CABELL_HUB_TELEMETRY) && not defined(AFHDS2A_HUB_TELEMETRY) && not defined(AFHDS2A_FW_TELEMETRY) && not defined(MULTI_TELEMETRY) && not defined(MULTI_STATUS) && not defined(HITEC_HUB_TELEMETRY) && not defined(HITEC_FW_TELEMETRY) && not defined(SCANNER_TELEMETRY)
 		#undef TELEMETRY
 		#undef INVERT_TELEMETRY


### PR DESCRIPTION
Fixes builds which don't have the CC2500 or don't have the scanner protocol enabled.