### PR TITLE
Add flag variables for binary file signature

### DIFF
--- a/Multiprotocol/Multiprotocol.ino
+++ b/Multiprotocol/Multiprotocol.ino
@@ -1962,3 +1962,20 @@ static uint32_t random_id(uint16_t address, uint8_t create_new)
 		}
 	}
 #endif
+
+// Set the flags for detecting and writing the firmware signature
+#if defined (CHECK_FOR_BOOTLOADER)
+    bool firmwareFlag_CHECK_FOR_BOOTLOADER = true;
+#endif
+#if defined (MULTI_STATUS)
+    bool firmwareFlag_MULTI_STATUS = true;
+#endif
+#if defined (MULTI_TELEMETRY)
+    bool firmwareFlag_MULTI_TELEMETRY = true;
+#endif
+#if defined (INVERT_TELEMETRY)
+    bool firmwareFlag_INVERT_TELEMETRY = true;
+#endif
+#if defined (DEBUG_SERIAL)
+    bool firmwareFlag_DEBUG_SERIAL = true;
+#endif


### PR DESCRIPTION
Adds variables which post-compilation scripts can use to detect build options and set the signature in the .bin file.