### PR TITLE
Protocol FrSky D16 receiver

### DIFF
--- a/Multiprotocol/FrSkyX_Rx_cc2500.ino
+++ b/Multiprotocol/FrSkyX_Rx_cc2500.ino
@@ -87,7 +87,6 @@ static void __attribute__((unused)) FrSkyX_Rx_initialise() {
 	CC2500_Strobe(CC2500_SFRX);
 	CC2500_Strobe(CC2500_SRX);
 	CC2500_WriteReg(CC2500_0A_CHANNR, 0);
-	CC2500_WriteReg(CC2500_25_FSCAL1, calData[0]);
 	delayMicroseconds(1000); // wait for RX to activate
 }
 

--- a/Multiprotocol/FrSkyX_Rx_cc2500.ino
+++ b/Multiprotocol/FrSkyX_Rx_cc2500.ino
@@ -120,7 +120,7 @@ static void __attribute__((unused)) frskyx_rx_calibrate()
 	}
 }
 
-uint8_t __attribute__((unused)) frskyx_rx_check_crc()
+static uint8_t __attribute__((unused)) frskyx_rx_check_crc()
 {
 	uint8_t limit = packet_length - 4;
 	uint16_t lcrc = frskyX_crc_x(&packet[3], limit - 3); // computed crc
@@ -128,7 +128,7 @@ uint8_t __attribute__((unused)) frskyx_rx_check_crc()
 	return lcrc == rcrc;
 }
 
-void __attribute__((unused)) frskyx_rx_build_telemetry_packet()
+static void __attribute__((unused)) frskyx_rx_build_telemetry_packet()
 {
 	uint16_t pxx_channel[8];
 	uint32_t bits = 0;

--- a/Multiprotocol/FrSkyX_Rx_cc2500.ino
+++ b/Multiprotocol/FrSkyX_Rx_cc2500.ino
@@ -13,6 +13,10 @@
  along with Multiprotocol.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#if defined(FRSKYX_RX_CC2500_INO)
+
+#include "iface_cc2500.h" 
+
  #define FRSKYX_FCC_LENGTH	30+2
  #define FRSKYX_LBT_LENGTH	33+2
 
@@ -297,3 +301,5 @@ uint16_t FrSkyX_Rx_callback()
 	}
 	return 1000;
 }
+
+#endif

--- a/Multiprotocol/FrSkyX_Rx_cc2500.ino
+++ b/Multiprotocol/FrSkyX_Rx_cc2500.ino
@@ -13,8 +13,8 @@
  along with Multiprotocol.  If not, see <http://www.gnu.org/licenses/>.
  */
 
- #define FRSKYX_FCC_LENGTH	30
- #define FRSKYX_LBT_LENGTH	33
+ #define FRSKYX_FCC_LENGTH	30+2
+ #define FRSKYX_LBT_LENGTH	33+2
 
  enum {
 	FRSKYX_RX_BIND,
@@ -122,7 +122,7 @@ static void __attribute__((unused)) frskyx_rx_calibrate()
 
 uint8_t __attribute__((unused)) frskyx_rx_check_crc()
 {
-	uint8_t limit = packet_length - 2;
+	uint8_t limit = packet_length - 4;
 	uint16_t lcrc = frskyX_crc_x(&packet[3], limit - 3); // computed crc
 	uint16_t rcrc = (packet[limit] << 8) | (packet[limit + 1] & 0xff); // received crc
 	return lcrc == rcrc;
@@ -257,7 +257,7 @@ uint16_t FrSkyX_Rx_callback()
 		if (len >= packet_length) {
 			CC2500_ReadData(packet, packet_length);
 			if (packet[1] == frskyx_rx_txid[0] && packet[2] == frskyx_rx_txid[1] && packet[6] == frskyx_rx_txid[2] && frskyx_rx_check_crc()) {
-				frskyx_rx_rssi = CC2500_ReadReg(CC2500_READ_BURST | CC2500_34_RSSI);
+				frskyx_rx_rssi = packet[packet_length-2];
 				if(frskyx_rx_rssi >= 128)
 					frskyx_rx_rssi -= 128;
 				else

--- a/Multiprotocol/FrSkyX_Rx_cc2500.ino
+++ b/Multiprotocol/FrSkyX_Rx_cc2500.ino
@@ -129,7 +129,7 @@ uint16_t initFrSkyX_Rx()
 {
 	FrSkyX_Rx_initialise();
 	frskyx_bind_check = 0;
-	frskyx_rx_chanskip = 0;
+	frskyx_rx_chanskip = 1;
 	hopping_frequency_no = 0;
 	frskyx_rx_data_started = 0;
 	if (IS_BIND_IN_PROGRESS) {

--- a/Multiprotocol/FrSkyX_Rx_cc2500.ino
+++ b/Multiprotocol/FrSkyX_Rx_cc2500.ino
@@ -81,7 +81,7 @@ static void __attribute__((unused)) FrSkyX_Rx_initialise() {
 		break;
 	}
 
-	CC2500_SetTxRxMode(RX_EN);  // Receive mode
+	CC2500_SetTxRxMode(TXRX_OFF);  // bypass lna, perhaps have an option for that ?
 
 	CC2500_Strobe(CC2500_SIDLE);
 	CC2500_Strobe(CC2500_SFRX);
@@ -228,9 +228,9 @@ uint16_t FrSkyX_Rx_callback()
 				counter = 0;
 			}
 		}
-		loops++;
+		
 		// skip channel if no packet received in time
-		if (loops >= 10) {
+		if (loops++ >= 9) {
 			debugln("!");
 			hopping_frequency_no = (hopping_frequency_no + frskyx_rx_chanskip) % 47;
 			frskyx_rx_set_channel(hopping_frequency_no);

--- a/Multiprotocol/FrSkyX_Rx_cc2500.ino
+++ b/Multiprotocol/FrSkyX_Rx_cc2500.ino
@@ -1,0 +1,216 @@
+/*
+ This project is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Multiprotocol is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Multiprotocol.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ #define FRSKYX_FCC_LENGTH	32
+ #define FRSKYX_LBT_LENGTH	35
+
+ enum {
+	FRSKYX_RX_BIND,
+	FRSKYX_RX_DATA,
+ };
+
+ static uint16_t frskyx_bind_packets;
+ static uint8_t frskyx_rx_txid[3];
+ static uint8_t frskyx_rx_chanskip;
+
+static void __attribute__((unused)) FrSkyX_Rx_initialise() {
+	CC2500_Reset();
+	
+	CC2500_WriteReg(CC2500_02_IOCFG0, 0x01);
+	CC2500_WriteReg(CC2500_18_MCSM0, 0x18);
+	CC2500_WriteReg(CC2500_07_PKTCTRL1, 0x04);
+	CC2500_WriteReg(CC2500_3E_PATABLE, 0xFF);
+	CC2500_WriteReg(CC2500_0C_FSCTRL0, 0x00);
+	CC2500_WriteReg(CC2500_0D_FREQ2, 0x5C);
+	CC2500_WriteReg(CC2500_13_MDMCFG1, 0x23);
+	CC2500_WriteReg(CC2500_14_MDMCFG0, 0x7A);
+	CC2500_WriteReg(CC2500_19_FOCCFG, 0x16);
+	CC2500_WriteReg(CC2500_1A_BSCFG, 0x6C);
+	CC2500_WriteReg(CC2500_1B_AGCCTRL2, 0x03);
+	CC2500_WriteReg(CC2500_1C_AGCCTRL1, 0x40);
+	CC2500_WriteReg(CC2500_1D_AGCCTRL0, 0x91);
+	CC2500_WriteReg(CC2500_21_FREND1, 0x56);
+	CC2500_WriteReg(CC2500_22_FREND0, 0x10);
+	CC2500_WriteReg(CC2500_23_FSCAL3, 0xA9);
+	CC2500_WriteReg(CC2500_24_FSCAL2, 0x0A);
+	CC2500_WriteReg(CC2500_25_FSCAL1, 0x00);
+	CC2500_WriteReg(CC2500_26_FSCAL0, 0x11);
+	CC2500_WriteReg(CC2500_29_FSTEST, 0x59);
+	CC2500_WriteReg(CC2500_2C_TEST2, 0x88);
+	CC2500_WriteReg(CC2500_2D_TEST1, 0x31);
+	CC2500_WriteReg(CC2500_2E_TEST0, 0x0B);
+	CC2500_WriteReg(CC2500_03_FIFOTHR, 0x07);
+	CC2500_WriteReg(CC2500_09_ADDR, 0x00);
+
+	switch (sub_protocol) {
+	case FRSKYX_FCC:
+		CC2500_WriteReg(CC2500_17_MCSM1, 0x0C);
+		CC2500_WriteReg(CC2500_0E_FREQ1, 0x76);
+		CC2500_WriteReg(CC2500_0F_FREQ0, 0x27);
+		CC2500_WriteReg(CC2500_06_PKTLEN, 0x1E);
+		CC2500_WriteReg(CC2500_08_PKTCTRL0, 0x01);
+		CC2500_WriteReg(CC2500_0B_FSCTRL1, 0x0A);
+		CC2500_WriteReg(CC2500_10_MDMCFG4, 0x7B);
+		CC2500_WriteReg(CC2500_11_MDMCFG3, 0x61);
+		CC2500_WriteReg(CC2500_12_MDMCFG2, 0x13);
+		CC2500_WriteReg(CC2500_15_DEVIATN, 0x51);
+		break;
+	case FRSKYX_LBT:
+		CC2500_WriteReg(CC2500_17_MCSM1, 0x0E);
+		CC2500_WriteReg(CC2500_0E_FREQ1, 0x80);
+		CC2500_WriteReg(CC2500_0F_FREQ0, 0x00);
+		CC2500_WriteReg(CC2500_06_PKTLEN, 0x23);
+		CC2500_WriteReg(CC2500_08_PKTCTRL0, 0x01);
+		CC2500_WriteReg(CC2500_0B_FSCTRL1, 0x08);
+		CC2500_WriteReg(CC2500_10_MDMCFG4, 0x7B);
+		CC2500_WriteReg(CC2500_11_MDMCFG3, 0xF8);
+		CC2500_WriteReg(CC2500_12_MDMCFG2, 0x03);
+		CC2500_WriteReg(CC2500_15_DEVIATN, 0x53);
+		break;
+	}
+
+	CC2500_SetTxRxMode(RX_EN);  // Receive mode
+
+	CC2500_Strobe(CC2500_SIDLE);
+	CC2500_Strobe(CC2500_SFRX);
+	CC2500_Strobe(CC2500_SRX);
+	CC2500_WriteReg(CC2500_0A_CHANNR, 0);
+	CC2500_WriteReg(CC2500_25_FSCAL1, calData[0]);
+	delayMicroseconds(1000); // wait for RX to activate
+}
+
+static void __attribute__((unused)) frskyx_rx_set_channel(uint8_t channel)
+{
+	CC2500_WriteReg(CC2500_0A_CHANNR, hopping_frequency[channel]);
+	CC2500_WriteReg(CC2500_25_FSCAL1, calData[channel]);
+	CC2500_Strobe(CC2500_SIDLE);
+	CC2500_Strobe(CC2500_SFRX);
+	CC2500_Strobe(CC2500_SRX);
+}
+
+static void __attribute__((unused)) frskyx_rx_calibrate()
+{
+	CC2500_Strobe(CC2500_SIDLE);
+	CC2500_Strobe(CC2500_SFRX);
+	CC2500_Strobe(CC2500_SRX);
+	for (unsigned c = 0; c < 47; c++)
+	{
+		CC2500_Strobe(CC2500_SIDLE);
+		CC2500_WriteReg(CC2500_0A_CHANNR, hopping_frequency[c]);
+		CC2500_Strobe(CC2500_SCAL);
+		delayMicroseconds(900);
+		calData[c] = CC2500_ReadReg(CC2500_25_FSCAL1);
+	}
+}
+
+uint8_t __attribute__((unused)) frskyx_rx_check_crc()
+{
+	uint8_t limit = packet_length - 4; //(sub_protocol == FRSKYX_LBT) ? 31 : 28;
+	uint16_t lcrc = frskyX_crc_x(&packet[3], limit - 3); // computed crc
+	uint16_t rcrc = (packet[limit] << 8) | (packet[limit + 1] & 0xff); // received crc
+	return lcrc == rcrc;
+}
+
+uint16_t initFrSkyX_Rx()
+{
+	debugln("initFrSkyX_Rx()");
+	FrSkyX_Rx_initialise();
+	frskyx_bind_packets = 0;
+	frskyx_rx_chanskip = 0;
+	hopping_frequency_no = 0;
+	phase = FRSKYX_RX_BIND;
+	packet_length = (sub_protocol == FRSKYX_LBT) ? FRSKYX_LBT_LENGTH : FRSKYX_FCC_LENGTH;
+	return 1000;
+}
+
+uint16_t FrSkyX_Rx_callback()
+{
+	static uint32_t lasttime=0, counter=0;
+	static int8_t loops=0;
+	uint8_t len;
+	switch(phase) {
+	case FRSKYX_RX_BIND:
+		len = CC2500_ReadReg(CC2500_3B_RXBYTES | CC2500_READ_BURST) & 0x7F;
+		if(len >= packet_length) {
+			CC2500_ReadData(packet, packet_length);
+			if (frskyx_rx_check_crc()) {
+				debug("bind:");
+				for(uint8_t i=0; i<len; i++)
+					debug(" %02X", packet[i]);
+				debugln("");
+				frskyx_rx_txid[0] = packet[3];
+				for (uint8_t ch = 0; ch < 5; ch++) {
+					hopping_frequency[packet[5]+ch] = packet[6+ch];
+					frskyx_bind_packets |= 1 << (packet[5] / 5);
+				}
+			}
+			if (frskyx_bind_packets == 0x3ff) {
+				debugln("bind complete");
+				frskyx_rx_calibrate();
+				CC2500_WriteReg(CC2500_18_MCSM0, 0x08); // FS_AUTOCAL = manual
+				CC2500_WriteReg(CC2500_09_ADDR, frskyx_rx_txid[0]); // set address
+				CC2500_WriteReg(CC2500_07_PKTCTRL1, 0x05); // check address
+				phase = FRSKYX_RX_DATA;
+				frskyx_rx_set_channel(hopping_frequency_no);
+			}
+			CC2500_Strobe(CC2500_SIDLE);
+			CC2500_Strobe(CC2500_SFRX);
+			CC2500_Strobe(CC2500_SRX);
+		}
+		return 1000;
+	case FRSKYX_RX_DATA:
+		len = CC2500_ReadReg(CC2500_3B_RXBYTES | CC2500_READ_BURST) & 0x7F;
+		if (len >= packet_length) {
+			CC2500_ReadData(packet, packet_length);
+			if (frskyx_rx_check_crc()) {
+				/*debug("%02X:", hopping_frequency_no);
+				for (uint8_t i = 0; i < len; i++)
+					debug(" %02X", packet[i]);
+				debugln("");*/
+
+				// hop to next channel
+				frskyx_rx_chanskip = ((packet[4] & 0xC0) >> 6) | ((packet[5] & 0x3F) << 2);
+				hopping_frequency_no = (hopping_frequency_no + frskyx_rx_chanskip) % 47;
+				frskyx_rx_set_channel(hopping_frequency_no);
+
+				if(packet[7] == 0) { // standard packet, decode PXX channels
+					// TODO, or just send raw PXX channels ?
+					int16_t chan1 = packet[9] | ((packet[10] & 0x0F) << 8);
+					int16_t chan2= ((packet[10] & 0xF0) >> 4) | (packet[11] << 4);
+					//if(chan1 < 2048)
+					//	debugln("Ch1: %d  Ch2: %d", chan1, chan2);
+				}
+				loops = 0;
+				counter++;
+			}
+			// debug packets per second
+			if (millis() - lasttime >= 1000) {
+				lasttime = millis();
+				debugln("%ld pps", counter);
+				counter = 0;
+			}
+		}
+		loops++;
+		// skip channel if no packet received in time
+		if (loops >= 10) {
+			debugln("!");
+			hopping_frequency_no = (hopping_frequency_no + frskyx_rx_chanskip) % 47;
+			frskyx_rx_set_channel(hopping_frequency_no);
+			loops = 0;
+		}
+		break;
+	}
+	return 1000;
+}

--- a/Multiprotocol/FrSkyX_Rx_cc2500.ino
+++ b/Multiprotocol/FrSkyX_Rx_cc2500.ino
@@ -197,16 +197,13 @@ uint16_t FrSkyX_Rx_callback()
 					eeprom_write_byte((EE_ADDR)temp++, hopping_frequency[ch]);
 				BIND_DONE;
 			}
-			CC2500_Strobe(CC2500_SIDLE);
-			CC2500_Strobe(CC2500_SFRX);
-			CC2500_Strobe(CC2500_SRX);
 		}
 		return 1000;
 	case FRSKYX_RX_DATA:
 		len = CC2500_ReadReg(CC2500_3B_RXBYTES | CC2500_READ_BURST) & 0x7F;
 		if (len >= packet_length) {
 			CC2500_ReadData(packet, packet_length);
-			if (frskyx_rx_check_crc()) {
+			if (packet[1] == frskyx_rx_txid[0] && packet[2] == frskyx_rx_txid[1] && packet[6] == frskyx_rx_txid[2] && frskyx_rx_check_crc()) {
 				// hop to next channel
 				frskyx_rx_chanskip = ((packet[4] & 0xC0) >> 6) | ((packet[5] & 0x3F) << 2);
 				hopping_frequency_no = (hopping_frequency_no + frskyx_rx_chanskip) % 47;

--- a/Multiprotocol/FrSkyX_cc2500.ino
+++ b/Multiprotocol/FrSkyX_cc2500.ino
@@ -66,7 +66,7 @@ static uint16_t __attribute__((unused)) frskyX_CRCTable(uint8_t val)
 	val /= 16 ;
 	return word ^ (0x1081 * val) ;
 }
-static uint16_t __attribute__((unused)) frskyX_crc_x(uint8_t *data, uint8_t len)
+uint16_t frskyX_crc_x(uint8_t *data, uint8_t len)
 {
 	uint16_t crc = 0;
 	for(uint8_t i=0; i < len; i++)

--- a/Multiprotocol/Multiprotocol.h
+++ b/Multiprotocol/Multiprotocol.h
@@ -81,6 +81,7 @@ enum PROTOCOLS
 	PROTO_ZSX		= 52,	// =>NRF24L01
 	PROTO_FLYZONE	= 53,	// =>A7105
 	PROTO_SCANNER	= 54,	// =>CC2500
+	PROTO_FRSKYX_RX	= 55,	// =>CC2500
 	PROTO_XN297DUMP	= 63,	// =>NRF24L01
 };
 
@@ -288,6 +289,11 @@ enum TRAXXAS
 {
 	RX6519	= 0,
 };
+enum FRSKYX_RX
+{
+	FRSKYX_FCC	= 0,
+	FRSKYX_LBT
+};
 
 #define NONE 		0
 #define P_HIGH		1
@@ -321,6 +327,7 @@ enum MultiPacketTypes
 	MULTI_TELEMETRY_HITEC			= 10,
 	MULTI_TELEMETRY_SCANNER			= 11,
 	MULTI_TELEMETRY_AFHDS2A_AC		= 12,
+	MULTI_TELEMETRY_CHANNELS		= 13,
 };
 
 // Macros
@@ -640,6 +647,7 @@ Serial: 100000 Baud 8e2      _ xxxx xxxx p --
 					ZSX			52
 					FLYZONE		53
 					SCANNER		54
+					FRSKYX_RX	55
    BindBit=>		0x80	1=Bind/0=No
    AutoBindBit=>	0x40	1=Yes /0=No
    RangeCheck=>		0x20	1=Yes /0=No
@@ -781,6 +789,9 @@ Serial: 100000 Baud 8e2      _ xxxx xxxx p --
 			RED_SLOW	1
 		sub_protocol==TRAXXAS
 			RX6519		0
+		sub_protocol==FRSKYX_RX
+			FCC			0
+			LBT			1
 
    Power value => 0x80	0=High/1=Low
   Stream[3]   = option_protocol;
@@ -898,5 +909,9 @@ Serial: 100000 Baud 8e2      _ xxxx xxxx p --
    length: 29
    data[0] = RSSI value
    data[1-28] telemetry data
+
+  Type 0x0D RX channels forwarding
+   length: 22
+   data[0-21] packed channels data, 16 channels, 11 bit per channel, msb first
 
 */

--- a/Multiprotocol/Multiprotocol.h
+++ b/Multiprotocol/Multiprotocol.h
@@ -327,7 +327,7 @@ enum MultiPacketTypes
 	MULTI_TELEMETRY_HITEC			= 10,
 	MULTI_TELEMETRY_SCANNER			= 11,
 	MULTI_TELEMETRY_AFHDS2A_AC		= 12,
-	MULTI_TELEMETRY_CHANNELS		= 13,
+	MULTI_TELEMETRY_RX_CHANNELS		= 13,
 };
 
 // Macros
@@ -912,7 +912,11 @@ Serial: 100000 Baud 8e2      _ xxxx xxxx p --
    data[1-28] telemetry data
 
   Type 0x0D RX channels forwarding
-   length: 22
-   data[0-21] packed channels data, 16 channels, 11 bit per channel, msb first
+   length: variable
+   data[0] = received packets per second
+   data[1] = rssi
+   data[2] = start channel
+   data[3] = number of channels to follow
+   data[4-]= packed channels data, 11 bit per channel
 
 */

--- a/Multiprotocol/Multiprotocol.h
+++ b/Multiprotocol/Multiprotocol.h
@@ -574,6 +574,7 @@ enum {
 #define AFHDS2A_EEPROM_OFFSET	50		// RX ID, 4 bytes per model id, end is 50+64=114
 #define BUGS_EEPROM_OFFSET		114		// RX ID, 2 bytes per model id, end is 114+32=146
 #define BUGSMINI_EEPROM_OFFSET	146		// RX ID, 2 bytes per model id, end is 146+32=178
+#define FRSKYX_RX_EEPROM_OFFSET	178		// TX ID + channels, 50 bytes per model, end is 178+200=378
 //#define CONFIG_EEPROM_OFFSET 	210		// Current configuration of the multimodule
 
 //****************************************

--- a/Multiprotocol/Multiprotocol.ino
+++ b/Multiprotocol/Multiprotocol.ino
@@ -647,7 +647,7 @@ uint8_t Update_All()
 	update_led_status();
 	#if defined(TELEMETRY)
 		#if ( !( defined(MULTI_TELEMETRY) || defined(MULTI_STATUS) ) )
-			if( (protocol == PROTO_FRSKYX_RX) || (protocol==PROTO_FRSKYX) || (protocol == PROTO_SCANNER) || (protocol==PROTO_FRSKYD) || (protocol==PROTO_BAYANG) || (protocol==PROTO_NCC1701) || (protocol==PROTO_BUGS) || (protocol==PROTO_BUGSMINI) || (protocol==PROTO_HUBSAN) || (protocol==PROTO_AFHDS2A) || (protocol==PROTO_FRSKYX) || (protocol==PROTO_DSM) || (protocol==PROTO_CABELL)  || (protocol==PROTO_HITEC))
+			if( (protocol == PROTO_FRSKYX_RX) || (protocol == PROTO_SCANNER) || (protocol==PROTO_FRSKYD) || (protocol==PROTO_BAYANG) || (protocol==PROTO_NCC1701) || (protocol==PROTO_BUGS) || (protocol==PROTO_BUGSMINI) || (protocol==PROTO_HUBSAN) || (protocol==PROTO_AFHDS2A) || (protocol==PROTO_FRSKYX) || (protocol==PROTO_DSM) || (protocol==PROTO_CABELL)  || (protocol==PROTO_HITEC))
 		#endif
 				TelemetryUpdate();
 	#endif
@@ -1028,7 +1028,7 @@ static void protocol_init()
 						remote_callback = Scanner_callback;
 						break;
 				#endif
-				#if defined(SCANNER_CC2500_INO)
+				#if defined(FRSKYX_RX_CC2500_INO)
 					case PROTO_FRSKYX_RX:
 						PE1_off;
 						PE2_on;	//antenna RF2

--- a/Multiprotocol/Multiprotocol.ino
+++ b/Multiprotocol/Multiprotocol.ino
@@ -647,7 +647,7 @@ uint8_t Update_All()
 	update_led_status();
 	#if defined(TELEMETRY)
 		#if ( !( defined(MULTI_TELEMETRY) || defined(MULTI_STATUS) ) )
-			if( (protocol == PROTO_SCANNER) || (protocol==PROTO_FRSKYD) || (protocol==PROTO_BAYANG) || (protocol==PROTO_NCC1701) || (protocol==PROTO_BUGS) || (protocol==PROTO_BUGSMINI) || (protocol==PROTO_HUBSAN) || (protocol==PROTO_AFHDS2A) || (protocol==PROTO_FRSKYX) || (protocol==PROTO_DSM) || (protocol==PROTO_CABELL)  || (protocol==PROTO_HITEC))
+			if( (protocol == PROTO_FRSKYX_RX) || (protocol==PROTO_FRSKYX)(protocol == PROTO_SCANNER) || (protocol==PROTO_FRSKYD) || (protocol==PROTO_BAYANG) || (protocol==PROTO_NCC1701) || (protocol==PROTO_BUGS) || (protocol==PROTO_BUGSMINI) || (protocol==PROTO_HUBSAN) || (protocol==PROTO_AFHDS2A) || (protocol==PROTO_FRSKYX) || (protocol==PROTO_DSM) || (protocol==PROTO_CABELL)  || (protocol==PROTO_HITEC))
 		#endif
 				TelemetryUpdate();
 	#endif
@@ -1026,6 +1026,14 @@ static void protocol_init()
 						PE2_on;	//antenna RF2
 						next_callback = initScanner();
 						remote_callback = Scanner_callback;
+						break;
+				#endif
+				#if defined(SCANNER_CC2500_INO)
+					case PROTO_FRSKYX_RX:
+						PE1_off;
+						PE2_on;	//antenna RF2
+						next_callback = initFrSkyX_Rx();
+						remote_callback = FrSkyX_Rx_callback;
 						break;
 				#endif
 			#endif

--- a/Multiprotocol/Multiprotocol.ino
+++ b/Multiprotocol/Multiprotocol.ino
@@ -647,7 +647,7 @@ uint8_t Update_All()
 	update_led_status();
 	#if defined(TELEMETRY)
 		#if ( !( defined(MULTI_TELEMETRY) || defined(MULTI_STATUS) ) )
-			if( (protocol == PROTO_FRSKYX_RX) || (protocol==PROTO_FRSKYX)(protocol == PROTO_SCANNER) || (protocol==PROTO_FRSKYD) || (protocol==PROTO_BAYANG) || (protocol==PROTO_NCC1701) || (protocol==PROTO_BUGS) || (protocol==PROTO_BUGSMINI) || (protocol==PROTO_HUBSAN) || (protocol==PROTO_AFHDS2A) || (protocol==PROTO_FRSKYX) || (protocol==PROTO_DSM) || (protocol==PROTO_CABELL)  || (protocol==PROTO_HITEC))
+			if( (protocol == PROTO_FRSKYX_RX) || (protocol==PROTO_FRSKYX) || (protocol == PROTO_SCANNER) || (protocol==PROTO_FRSKYD) || (protocol==PROTO_BAYANG) || (protocol==PROTO_NCC1701) || (protocol==PROTO_BUGS) || (protocol==PROTO_BUGSMINI) || (protocol==PROTO_HUBSAN) || (protocol==PROTO_AFHDS2A) || (protocol==PROTO_FRSKYX) || (protocol==PROTO_DSM) || (protocol==PROTO_CABELL)  || (protocol==PROTO_HITEC))
 		#endif
 				TelemetryUpdate();
 	#endif

--- a/Multiprotocol/Telemetry.ino
+++ b/Multiprotocol/Telemetry.ino
@@ -184,6 +184,19 @@ static void multi_send_status()
 	}
 #endif
 
+#ifdef FRSKYX_RX_TELEMETRY
+	void frskyx_rx_channels_frame()
+	{
+		#if defined MULTI_TELEMETRY
+				multi_send_header(MULTI_TELEMETRY_RX_CHANNELS, 26);
+		#else
+				Serial_write(0xAA);					// Telemetry packet
+		#endif
+		for (uint8_t i = 0; i < 26; i++)
+			Serial_write(pkt[i]);					// pps, rssi, ch start, ch count, 16x ch data
+	}
+#endif
+
 #ifdef AFHDS2A_FW_TELEMETRY
 	void AFHDSA_short_frame()
 	{
@@ -1022,8 +1035,7 @@ void TelemetryUpdate()
 	#if defined FRSKYX_RX_TELEMETRY
 		if (telemetry_link && protocol == PROTO_FRSKYX_RX)
 		{
-			// TODO
-			//channels_frame();
+			frskyx_rx_channels_frame();
 			telemetry_link = 0;
 			return;
 		}

--- a/Multiprotocol/Telemetry.ino
+++ b/Multiprotocol/Telemetry.ino
@@ -1019,6 +1019,16 @@ void TelemetryUpdate()
 		}
 	#endif
 
+	#if defined FRSKYX_RX_TELEMETRY
+		if (telemetry_link && protocol == PROTO_FRSKYX_RX)
+		{
+			// TODO
+			//channels_frame();
+			telemetry_link = 0;
+			return;
+		}
+	#endif
+
 		if((telemetry_link & 1 )&& protocol != PROTO_FRSKYX)
 		{	// FrSkyD + Hubsan + AFHDS2A + Bayang + Cabell + Hitec + Bugs + BugsMini + NCC1701
 			frsky_link_frame();

--- a/Multiprotocol/Validate.h
+++ b/Multiprotocol/Validate.h
@@ -250,6 +250,7 @@
 	#undef MULTI_STATUS
 	#undef MULTI_TELEMETRY
 	#undef SCANNER_TELEMETRY
+	#undef FRSKYX_RX_TELEMETRY
 #else
 	#if defined MULTI_TELEMETRY && not defined INVERT_TELEMETRY
 		#warning MULTI_TELEMETRY has been defined but not INVERT_TELEMETRY. They should be both enabled for OpenTX telemetry and status to work.

--- a/Multiprotocol/Validate.h
+++ b/Multiprotocol/Validate.h
@@ -272,7 +272,7 @@
 	#if not defined(NCC1701_NRF24L01_INO)
 		#undef NCC1701_HUB_TELEMETRY
 	#endif
-	#if not defined(BUGS_A7105_INO) || not defined(BUGSMINI_NRF24L01_INO)
+	#if not defined(BUGS_A7105_INO) && not defined(BUGSMINI_NRF24L01_INO)
 		#undef BUGS_HUB_TELEMETRY
 	#endif
 	#if not defined(CABELL_NRF24L01_INO)

--- a/Multiprotocol/_Config.h
+++ b/Multiprotocol/_Config.h
@@ -174,6 +174,7 @@
 #define	FRSKYD_CC2500_INO
 #define	FRSKYV_CC2500_INO
 #define	FRSKYX_CC2500_INO
+#define	FRSKYX_RX_CC2500_INO
 #define	HITEC_CC2500_INO
 #define	SCANNER_CC2500_INO
 #define	SFHSS_CC2500_INO
@@ -296,6 +297,7 @@
 #define HITEC_HUB_TELEMETRY			// Use FrSkyD Hub format to send basic telemetry to the radios which can decode it like er9x, ersky9x and OpenTX
 #define HITEC_FW_TELEMETRY			// Under development: Forward received telemetry packets to be decoded by ersky9x and OpenTX
 #define SCANNER_TELEMETRY			// Forward spectrum scanner data to TX
+#define FRSKYX_RX_TELEMETRY			// Forward channels data to TX
 
 //SPORT_POLLING is an implementation of the same polling routine as XJT module for sport telemetry bidirectional communication.
 //This is useful for passing sport control frames from TX to RX(ex: changing Betaflight PID or VTX channels on the fly using LUA scripts with OpentX).
@@ -547,6 +549,9 @@ const PPM_Parameters PPM_prot[14*NBR_BANKS]=	{
 		CH_8
 		EU_16
 		EU_8
+	PROTO_FRSKYX_RX
+		FCC
+		LBT
 	PROTO_FY326
 		FY326
 		FY319


### PR DESCRIPTION
Add FrSky D16 receiver protocol to be used as a wireless training "cable" by OpenTX 2.3+

Protocol#: 55
sub proto 0: FCC
sub proto 1: EU(LBT)
option: frequency fine tune
low power mode: disable lna