### PR TITLE
Fix STM32 PB1 definition

### DIFF
--- a/Multiprotocol/Multiprotocol.ino
+++ b/Multiprotocol/Multiprotocol.ino
@@ -300,7 +300,6 @@ void setup()
 		pinMode(S4_pin,INPUT_PULLUP);
 		//Random pins
 		pinMode(PB0, INPUT_ANALOG); // set up pin for analog input
-		pinMode(PB1, INPUT_ANALOG); // set up pin for analog input
 
 		//Timers
 		init_HWTimer();			//0.5us


### PR DESCRIPTION
PB1 is the control pin for serial inversion on the RX pin.  It is correctly defined above as a digital output then for some reason redefined as an analog input.  I can't see any good reason for the redefinition, and it breaks control of the serial RX inversion pin in my STM32 HAL-based bootloader.

(TBH, I can't see any reason to define PB0 (which isn't connected) either.)