### PR TITLE
Direct inputs

### DIFF
--- a/Multiprotocol/Multiprotocol.ino
+++ b/Multiprotocol/Multiprotocol.ino
@@ -667,7 +667,22 @@ bool Update_All()
 		{
 			uint32_t chan_or=chan_order;
 			uint8_t ch;
-			for(uint8_t i=0;i<PPM_chan_max;i++)
+			uint8_t channels_count = PPM_chan_max;
+			#ifdef ENABLE_DIRECT_INPUTS
+				#ifdef DI_CH1_read
+					PPM_data[channels_count++] = DI_CH1_read
+				#endif
+				#ifdef DI_CH2_read
+					PPM_data[channels_count++] = DI_CH2_read
+				#endif
+				#ifdef DI_CH3_read
+					PPM_data[channels_count++] = DI_CH3_read
+				#endif
+				#ifdef DI_CH4_read
+					PPM_data[channels_count++] = DI_CH4_read
+				#endif
+			#endif
+			for(uint8_t i=0;i<channels_count;i++)
 			{ // update servo data without interrupts to prevent bad read
 				uint16_t val;
 				cli();										// disable global int

--- a/Multiprotocol/Multiprotocol.ino
+++ b/Multiprotocol/Multiprotocol.ino
@@ -331,6 +331,21 @@ void setup()
 		pinMode(S2_pin,INPUT_PULLUP);
 		pinMode(S3_pin,INPUT_PULLUP);
 		pinMode(S4_pin,INPUT_PULLUP);
+
+		#if defined ENABLE_DIRECT_INPUTS
+			#if defined (DI1_PIN)
+				pinMode(DI1_PIN,INPUT_PULLUP);
+			#endif
+			#if defined (DI2_PIN)
+				pinMode(DI2_PIN,INPUT_PULLUP);
+			#endif
+			#if defined (DI3_PIN)
+				pinMode(DI3_PIN,INPUT_PULLUP);
+			#endif
+			#if defined (DI4_PIN)
+				pinMode(DI4_PIN,INPUT_PULLUP);
+			#endif
+		#endif
 		//Random pins
 		pinMode(PB0, INPUT_ANALOG); // set up pin for analog input
 
@@ -666,23 +681,29 @@ bool Update_All()
 		if(mode_select!=MODE_SERIAL && IS_PPM_FLAG_on)		// PPM mode and a full frame has been received
 		{
 			uint32_t chan_or=chan_order;
-			uint8_t ch;
-			uint8_t channels_count = PPM_chan_max;
-			#ifdef ENABLE_DIRECT_INPUTS
+			uint8_t ch;		
+			uint8_t channelsCount = PPM_chan_max;
+			
+			#ifdef ENABLE_DIRECT_INPUTS				
 				#ifdef DI_CH1_read
-					PPM_data[channels_count++] = DI_CH1_read
+					PPM_data[channelsCount] = DI_CH1_read;
+					channelsCount++;
 				#endif
 				#ifdef DI_CH2_read
-					PPM_data[channels_count++] = DI_CH2_read
+					PPM_data[channelsCount] = DI_CH2_read;
+					channelsCount++;
 				#endif
 				#ifdef DI_CH3_read
-					PPM_data[channels_count++] = DI_CH3_read
+					PPM_data[channelsCount] = DI_CH3_read;
+					channelsCount++;
 				#endif
 				#ifdef DI_CH4_read
-					PPM_data[channels_count++] = DI_CH4_read
-				#endif
+					PPM_data[channelsCount] = DI_CH4_read;
+					channelsCount++;
+				#endif 
 			#endif
-			for(uint8_t i=0;i<channels_count;i++)
+			
+			for(uint8_t i=0;i<channelsCount;i++)
 			{ // update servo data without interrupts to prevent bad read
 				uint16_t val;
 				cli();										// disable global int
@@ -703,6 +724,7 @@ bool Update_All()
 				else
 					Channel_data[i]=val;
 			}
+       
 			PPM_FLAG_off;									// wait for next frame before update
 			#ifdef FAILSAFE_ENABLE
 				PPM_failsafe();

--- a/Multiprotocol/Pins.h
+++ b/Multiprotocol/Pins.h
@@ -312,7 +312,7 @@
 		#define DEBUG_PIN_off
 		#define DEBUG_PIN_toggle
 	#endif
-
+	
 	#define	cli() 			noInterrupts()
 	#define	sei() 			interrupts()
 	#define	delayMilliseconds(x) delay(x)

--- a/Multiprotocol/Validate.h
+++ b/Multiprotocol/Validate.h
@@ -414,3 +414,18 @@
 #if defined (STM32_BOARD) && defined (DEBUG_SERIAL) && defined (NRF24L01_INSTALLED)
 	#define XN297DUMP_NRF24L01_INO
 #endif
+
+//Check if Direct inputs defined correctly
+#if defined (ENABLE_DIRECT_INPUTS) 
+	#if not defined (STM32_BOARD) || not defined (ENABLE_PPM) || defined (ENABLE_SERIAL)
+		#error You can enable dirct inputs only in PPM mode and only for STM32 board.
+	#endif
+
+	#if not defined (DI1_PIN) && not defined (DI2_PIN) && not defined (DI3_PIN) && not defined (DI4_PIN)
+		#error You must define at least 1 direct input pin or undefine ENABLE_DIRECT_INPUTS in config.
+	#endif
+	
+	#if not defined (DI_CH1_read) && not defined (DI_CH2_read) && not defined (DI_CH3_read) && not defined (DI_CH4_read)
+		#error You must define at least 1 direct input chanell read macros or undefine ENABLE_DIRECT_INPUTS in config.
+	#endif
+#endif

--- a/Multiprotocol/_Config.h
+++ b/Multiprotocol/_Config.h
@@ -494,36 +494,27 @@ const PPM_Parameters PPM_prot[14*NBR_BANKS]=	{
 /**********************************/
 //In this section you can configure the direct inputs.
 //It enables switches wired directly to the board
-//Current mappings are: AUX1-PB10, AUX2-PB11, AUX3-PA2, AUX4-PA3
 //Direct inputs works only in ppm mode and only for stm_32 boards
-#if defined(ENABLE_PPM) && defined (STM32_BOARD) && not defined (ENABLE_SERIAL)
+//Uncomment following lines to enable derect inputs or define your own configuration in _MyConfig.h
+/*
+#define ENABLE_DIRECT_INPUTS
+		
+#define DI1_PIN				PC13	
+#define IS_DI1_on			(digitalRead(DI1_PIN)==LOW)
 
-	//If plan to use direct input mode please uncomment lines below
-	#define ENABLE_DIRECT_INPUTS
-	//
-	
-	#define DI1_PIN				PC13
-	#define DI1_SET_INPUT 		pinMode(DI1_PIN,INPUT)
-	#define DI1_SET_PULLUP 		digitalWrite(DI1_PIN,HIGH)
-	#define IS_DI1_on			(digitalRead(DI1_PIN)==LOW)
+#define DI2_PIN				PC14	
+#define IS_DI2_on			(digitalRead(DI2_PIN)==LOW)
 
-	#define DI2_PIN				PC14
-	#define DI2_SET_INPUT 		pinMode(DI2_PIN,INPUT)
-	#define DI2_SET_PULLUP 		digitalWrite(DI2_PIN,HIGH)
-	#define IS_DI2_on			(digitalRead(DI2_PIN)==LOW)
+#define DI3_PIN				PC15	
+#define IS_DI3_on			(digitalRead(DI3_PIN)==LOW)
 
-	#define DI3_PIN				PC15
-	#define DI3_SET_INPUT 		pinMode(DI3_PIN,INPUT)
-	#define DI3_SET_PULLUP 		digitalWrite(DI3_PIN,HIGH)
-	#define IS_DI3_on			(digitalRead(DI3_PIN)==LOW)
+//Define up to 4 direct input channels
+//CHANNEL1 - 2pos switch
+#define DI_CH1_read			IS_DI1_on ? PPM_MAX_100*2 : PPM_MIN_100*2
+//CHANNEL2 - 3pos switch
+#define DI_CH2_read			IS_DI2_on ? PPM_MAX_100*2 : (IS_DI2_on ? PPM_MAX_100 + PPM_MIN_100 : PPM_MIN_100*2)
+*/
 
-	//CHANNEL1 - 2pos switch
-	#define DI_CH1_read			IS_DI1_on ? PPM_MAX_100*2 : PPM_MIN_100*2
-
-	//CHANNEL2 - 3pos switch
-	#define DI_CH2_read			IS_DI2_on ? PPM_MAX_100*2 : (IS_DI2_on ? PPM_MAX_100 + PPM_MIN_100 : PPM_MIN_100*2)
-
-#endif
 /* Available protocols and associated sub protocols to pick and choose from (Listed in alphabetical order)
 	PROTO_AFHDS2A
 		PWM_IBUS

--- a/Multiprotocol/_Config.h
+++ b/Multiprotocol/_Config.h
@@ -23,7 +23,7 @@
 //If you know parameters you want for sure to be enabled or disabled which survives in future, you can use a file named "_MyConfig.h".
 //An example is given within the file named "_MyConfig.h.example" which needs to be renamed if you want to use it.
 //To enable this config file remove the // from the line below.
-//#define USE_MY_CONFIG
+#define USE_MY_CONFIG
 
 
 /*************************/
@@ -498,15 +498,31 @@ const PPM_Parameters PPM_prot[14*NBR_BANKS]=	{
 //Direct inputs works only in ppm mode and only for stm_32 boards
 #if defined(ENABLE_PPM) && defined (STM32_BOARD) && not defined (ENABLE_SERIAL)
 
-//If plan to use direct input mode please uncomment lines below
-//#define ENABLE_DIRECT_INPUTS
-//
-//Direct inputs start channel
-//Uncomment and change from what channel direct inputs starts
-//#define DIRECT_INPUTS_START 7
-//
+	//If plan to use direct input mode please uncomment lines below
+	#define ENABLE_DIRECT_INPUTS
+	//
+	
+	#define DI1_PIN				PC13
+	#define DI1_SET_INPUT 		pinMode(DI1_PIN,INPUT)
+	#define DI1_SET_PULLUP 		digitalWrite(DI1_PIN,HIGH)
+	#define IS_DI1_on			(digitalRead(DI1_PIN)==LOW)
 
-#endif
+	#define DI2_PIN				PC14
+	#define DI2_SET_INPUT 		pinMode(DI2_PIN,INPUT)
+	#define DI2_SET_PULLUP 		digitalWrite(DI2_PIN,HIGH)
+	#define IS_DI2_on			(digitalRead(DI2_PIN)==LOW)
+
+	#define DI3_PIN				PC15
+	#define DI3_SET_INPUT 		pinMode(DI3_PIN,INPUT)
+	#define DI3_SET_PULLUP 		digitalWrite(DI3_PIN,HIGH)
+	#define IS_DI3_on			(digitalRead(DI3_PIN)==LOW)
+
+	//CHANNEL1 - 2pos switch
+	#define DI_CH1_read			IS_DI1_on ? PPM_MAX_100*2 : PPM_MIN_100*2
+
+	//CHANNEL2 - 3pos switch
+	#define DI_CH2_read			IS_DI2_on ? PPM_MAX_100*2 : (IS_DI2_on ? PPM_MAX_100 + PPM_MIN_100 : PPM_MIN_100*2)
+
 #endif
 /* Available protocols and associated sub protocols to pick and choose from (Listed in alphabetical order)
 	PROTO_AFHDS2A

--- a/Multiprotocol/_Config.h
+++ b/Multiprotocol/_Config.h
@@ -23,7 +23,7 @@
 //If you know parameters you want for sure to be enabled or disabled which survives in future, you can use a file named "_MyConfig.h".
 //An example is given within the file named "_MyConfig.h.example" which needs to be renamed if you want to use it.
 //To enable this config file remove the // from the line below.
-#define USE_MY_CONFIG
+//#define USE_MY_CONFIG
 
 
 /*************************/

--- a/Multiprotocol/_Config.h
+++ b/Multiprotocol/_Config.h
@@ -488,6 +488,26 @@ const PPM_Parameters PPM_prot[14*NBR_BANKS]=	{
 //  - 0x40010000 will give to the protocol the channels in the order 4,2,3,1,5,6,7,8 swapping channel 1 and 4. Note: 0 means leave the channel where it is.
 //  - 0x0000ABCD will give to the protocol the channels in the order 1,2,3,4,10,11,12,13 which potentially enables acces to channels not available on your TX. Note A=10,B=11,C=12,D=13,E=14,F=15.
 
+
+/**********************************/
+/*** DIRECT INPUTS SETTINGS ***/
+/**********************************/
+//In this section you can configure the direct inputs.
+//It enables switches wired directly to the board
+//Current mappings are: AUX1-PB10, AUX2-PB11, AUX3-PA2, AUX4-PA3
+//Direct inputs works only in ppm mode and only for stm_32 boards
+#if defined(ENABLE_PPM) && defined (STM32_BOARD) && not defined (ENABLE_SERIAL)
+
+//If plan to use direct input mode please uncomment lines below
+//#define ENABLE_DIRECT_INPUTS
+//
+//Direct inputs start channel
+//Uncomment and change from what channel direct inputs starts
+//#define DIRECT_INPUTS_START 7
+//
+
+#endif
+#endif
 /* Available protocols and associated sub protocols to pick and choose from (Listed in alphabetical order)
 	PROTO_AFHDS2A
 		PWM_IBUS


### PR DESCRIPTION
As far we have few unused pins on stm32 it's possible to wire inputs to this pins. 
I'd install multiprotocol moule to my old Spektrum DX6i and it works like a charm, but since I started play with multirotors I expirenced some lack of channels for all this arm/beep/flight mode... 
This PR solved my problem and can help someone else.

Of course it's not easy enough to wire thin wires directly to stm32 pins, but not impossible. BTW we have 1 pin that can be used as-is without soldering - DEBUG_PIN. But I prefer PC13, PC14, PC15 and also we can use PB0 as analog input.

If you know another unused pins that an be used without soldering - it will be great!

Since my code do not break any existing logic - it's safe to merge. If you need some more explanations or fixes - let me know!