### PR TITLE
Fix module status on erSkyTX

### DIFF
--- a/Multiprotocol/Telemetry.ino
+++ b/Multiprotocol/Telemetry.ino
@@ -125,7 +125,11 @@ static void multi_send_status()
 		multi_send_header(MULTI_TELEMETRY_STATUS, 24);
 	else
 	#endif
+		#ifdef MULTI_TELEMETRY
 		multi_send_header(MULTI_TELEMETRY_STATUS, 6);
+		#else
+		multi_send_header(MULTI_TELEMETRY_STATUS, 5);
+		#endif
 
 	// Build flags
 	uint8_t flags=0;
@@ -167,7 +171,9 @@ static void multi_send_status()
 	Serial_write(VERSION_PATCH_LEVEL);
 
 	// Channel order
+	#ifdef MULTI_TELEMETRY
 	Serial_write(RUDDER<<6|THROTTLE<<4|ELEVATOR<<2|AILERON);
+	#endif
 	
 	#ifdef MULTI_NAMES
 		if(multi_protocols_index != 0xFF)


### PR DESCRIPTION
erSkyTX on my 9XR-Pro would not display the MULTI-Module firmware version number when it had the channel order appended.