### PR TITLE
Initial Version of CloneMode

### DIFF
--- a/Multiprotocol/FrSkyDVX_common.ino
+++ b/Multiprotocol/FrSkyDVX_common.ino
@@ -113,12 +113,13 @@ void Frsky_init_clone(void)
   temp++;
   rx_tx_addr[3] = eeprom_read_byte((EE_ADDR)temp++);
   rx_tx_addr[2] = eeprom_read_byte((EE_ADDR)temp++);
-  temp++;
   hw_ver = eeprom_read_byte((EE_ADDR)temp++);
+  temp++;
   for (uint8_t ch = 0; ch < 47; ch++)
   {
     hopping_frequency[ch] = eeprom_read_byte((EE_ADDR)temp++);
   }
+  debugln("Clone mode");
 }
 
 #endif

--- a/Multiprotocol/FrSkyDVX_common.ino
+++ b/Multiprotocol/FrSkyDVX_common.ino
@@ -105,6 +105,22 @@ void FrSkyX2_init_hop(void)
 	hopping_frequency[47] = 0;									//Bind freq
 }
 
+uint8_t hw_ver=0x02;
+
+void Frsky_init_clone(void)
+{
+  uint16_t temp = FRSKY_RX_EEPROM_OFFSET;
+  temp++;
+  rx_tx_addr[3] = eeprom_read_byte((EE_ADDR)temp++);
+  rx_tx_addr[2] = eeprom_read_byte((EE_ADDR)temp++);
+  temp++;
+  hw_ver = eeprom_read_byte((EE_ADDR)temp++);
+  for (uint8_t ch = 0; ch < 47; ch++)
+  {
+    hopping_frequency[ch] = eeprom_read_byte((EE_ADDR)temp++);
+  }
+}
+
 #endif
 /******************************/
 /**  FrSky V, D and X routines  **/

--- a/Multiprotocol/FrSkyX_cc2500.ino
+++ b/Multiprotocol/FrSkyX_cc2500.ino
@@ -385,8 +385,7 @@ uint16_t ReadFrSkyX()
 uint16_t initFrSkyX()
 {
 	set_rx_tx_addr(MProtocol_id_master);
-
-  if ((eeprom_read_byte((EE_ADDR)FRSKY_RX_EEPROM_OFFSET+3)==15) && (eeprom_read_byte((EE_ADDR)FRSKY_RX_EEPROM_OFFSET)<2))// bound in FRSKY-X RX-mode with num 63 -> use clone mode
+  if ((eeprom_read_byte((EE_ADDR)FRSKY_RX_EEPROM_OFFSET+4)==127) && (eeprom_read_byte((EE_ADDR)FRSKY_RX_EEPROM_OFFSET)<2))// bound in FRSKY-X RX-mode with RX Num 63 -> use clone mode
     Frsky_init_clone();
   else if(protocol==PROTO_FRSKYX)
 		Frsky_init_hop();

--- a/Multiprotocol/FrSkyX_cc2500.ino
+++ b/Multiprotocol/FrSkyX_cc2500.ino
@@ -42,7 +42,7 @@ static void __attribute__((unused)) FrSkyX_build_bind_packet()
 		packet[8] = hopping_frequency[idx++];
 		packet[9] = hopping_frequency[idx++];
 		packet[10] = hopping_frequency[idx++];
-		packet[11] = 0x02;					// Unknown but constant ID?
+		packet[11] = hw_ver;					// Unknown but constant ID?
 		packet[12] = RX_num;
 		//
 		memset(&packet[13], 0, packet_size - 14);
@@ -54,7 +54,7 @@ static void __attribute__((unused)) FrSkyX_build_bind_packet()
 	else
 	{
 		//packet 1D 03 01 0E 1C 02 00 00 32 0B 00 00 A8 26 28 01 A1 00 00 00 3E F6 87 C7 00 00 00 00 C9 C9
-		packet[5] = 0x02;					// Unknown but constant ID?
+		packet[5] = hw_ver;					// Unknown but constant ID?
 		packet[6] = RX_num;
 		//Bind flags
 		packet[7]=0;
@@ -119,7 +119,7 @@ static void __attribute__((unused)) FrSkyX_build_packet()
 	packet[0] = packet_size;			// Number of bytes in the packet (after this one)
 	packet[1] = rx_tx_addr[3];			// ID
 	packet[2] = rx_tx_addr[2];			// ID
-	packet[3] = 0x02;					// Unknown but constant ID?
+	packet[3] = hw_ver;					// Unknown but constant ID?
 	//  
 	packet[4] = (FrSkyX_chanskip<<6)|hopping_frequency_no; 
 	packet[5] = FrSkyX_chanskip>>2;
@@ -386,7 +386,9 @@ uint16_t initFrSkyX()
 {
 	set_rx_tx_addr(MProtocol_id_master);
 
-	if(protocol==PROTO_FRSKYX)
+  if ((eeprom_read_byte((EE_ADDR)FRSKY_RX_EEPROM_OFFSET+3)==15) && (eeprom_read_byte((EE_ADDR)FRSKY_RX_EEPROM_OFFSET)<2))// bound in FRSKY-X RX-mode with num 63 -> use clone mode
+    Frsky_init_clone();
+  else if(protocol==PROTO_FRSKYX)
 		Frsky_init_hop();
 	else
 	{

--- a/Multiprotocol/FrSky_Rx_cc2500.ino
+++ b/Multiprotocol/FrSky_Rx_cc2500.ino
@@ -314,8 +314,7 @@ uint16_t FrSky_Rx_callback()
 			if(packet[1] == 0x03 && packet[2] == 0x01 && frskyx_rx_check_crc()) {
 				rx_tx_addr[0] = packet[3];	// TXID
 				rx_tx_addr[1] = packet[4];	// TXID
-				rx_tx_addr[2] = packet[12];	// TXID
-				rx_tx_addr[3] = packet[11]; // HW-Version #
+				rx_tx_addr[2] = packet[11];	// TXID
 				frsky_rx_finetune = -127;
 				CC2500_WriteReg(CC2500_0C_FSCTRL0, frsky_rx_finetune);
 				phase = FRSKY_RX_TUNE_LOW;
@@ -393,15 +392,16 @@ uint16_t FrSky_Rx_callback()
 					eeprom_write_byte((EE_ADDR)temp++, rx_tx_addr[2]);
 					debug("addr[2]=%02X, ", rx_tx_addr[2]);
 					debug("rx_num=%02X, ", packet[12]); // RX # (D16)
-          if (rx_tx_addr[2]==15)
+          if (packet[12]==63)
           {
-            eeprom_write_byte((EE_ADDR)temp++, rx_tx_addr[3]);
-            debug("hw_ver=%02X, ", rx_tx_addr[3]);
+            // If RX Num is 63, write a finetune value of 127 to the EEPROM
+            // A real finetune value of 127 means, the frequency of module is out of range and the module should be replaced.
+            eeprom_write_byte((EE_ADDR)temp++, 127);
           }
           else
           {
             eeprom_write_byte((EE_ADDR)temp++, frsky_rx_finetune);
-           debugln("tune=%d", (int8_t)frsky_rx_finetune);
+            debugln("tune=%d", (int8_t)frsky_rx_finetune);
           }
 					for (ch = 0; ch < 47; ch++)
 					{

--- a/Multiprotocol/FrSky_Rx_cc2500.ino
+++ b/Multiprotocol/FrSky_Rx_cc2500.ino
@@ -314,7 +314,8 @@ uint16_t FrSky_Rx_callback()
 			if(packet[1] == 0x03 && packet[2] == 0x01 && frskyx_rx_check_crc()) {
 				rx_tx_addr[0] = packet[3];	// TXID
 				rx_tx_addr[1] = packet[4];	// TXID
-				rx_tx_addr[2] = packet[11];	// TXID
+				rx_tx_addr[2] = packet[12];	// TXID
+				rx_tx_addr[3] = packet[11]; // HW-Version #
 				frsky_rx_finetune = -127;
 				CC2500_WriteReg(CC2500_0C_FSCTRL0, frsky_rx_finetune);
 				phase = FRSKY_RX_TUNE_LOW;
@@ -392,8 +393,16 @@ uint16_t FrSky_Rx_callback()
 					eeprom_write_byte((EE_ADDR)temp++, rx_tx_addr[2]);
 					debug("addr[2]=%02X, ", rx_tx_addr[2]);
 					debug("rx_num=%02X, ", packet[12]); // RX # (D16)
-					eeprom_write_byte((EE_ADDR)temp++, frsky_rx_finetune);
-					debugln("tune=%d", (int8_t)frsky_rx_finetune);
+          if (rx_tx_addr[2]==15)
+          {
+            eeprom_write_byte((EE_ADDR)temp++, rx_tx_addr[3]);
+            debug("hw_ver=%02X, ", rx_tx_addr[3]);
+          }
+          else
+          {
+            eeprom_write_byte((EE_ADDR)temp++, frsky_rx_finetune);
+           debugln("tune=%d", (int8_t)frsky_rx_finetune);
+          }
 					for (ch = 0; ch < 47; ch++)
 					{
 						eeprom_write_byte((EE_ADDR)temp++, hopping_frequency[ch]);


### PR DESCRIPTION
- Bind an FRSKY_X Transmitter with RX-Number 15 (Should be changed to 63, but I'm on OTX2.2.x at the moment and there is 15 the highest RX-Number) to your secondary TX using Multimodule in FRSKY-RX mode.
- Use a secondary TX to create (or copy) a model using Multimodule in FRSKY-TX mode and use the RX-Number of the model in the original TX
Now you can use both transmitters without rebinding the RX

It's useful, if you have a full size TX like Taranis or Horus and a second lightweight TX like XLite.
