### PR TITLE
Change DFU Bootloader driver to libusbk

### DIFF
--- a/BootLoaders/Boards/Windows/install_drivers.bat
+++ b/BootLoaders/Boards/Windows/install_drivers.bat
@@ -1,11 +1,11 @@
 @echo off
 
-echo Installing Maple DFU driver...
-"%~dp0wdi-simple" --vid 0x1EAF --pid 0x0003 --type 1 --name "Maple DFU" --dest "%~dp0maple-dfu"
+echo Installing MULTI-Module DFU Bootloader Driver...
+"%~dp0wdi-simple" --vid 0x1EAF --pid 0x0003 --type 2 --name "MULTI-Module DFU Bootloader" --dest "%~dp0MULTI-DFU-Bootloader" -b
 echo.
 
-echo Installing Maple Serial driver...
-"%~dp0wdi-simple" --vid 0x1EAF --pid 0x0004 --type 3 --name "Maple Serial" --dest "%~dp0maple-serial"
+echo Installing MULTI-Module USB Serial Driver...
+"%~dp0wdi-simple" --vid 0x1EAF --pid 0x0004 --type 3 --name "MULTI-Module USB Serial" --dest "%~dp0MULTI-USB-Serial" -b
 echo.
 
 pause


### PR DESCRIPTION
Updates the Windows driver installer script to use the libusbk driver for DFU Bootloader more instead of the libusb-win32 driver.  The libusbk driver is reliable and is required for newer versions of dfu-util, including the version included in the latest STM32 boards package (v1.1.8).

Also updates the device display names used in Device Manager:
* `Maple DFU` is now `MULTI-Module DFU Bootloader`
* `Maple Serial` is now `MULTI-Module USB Serial`

Changes only apply to new installations (where drivers have never been installed).  [Zadig](https://zadig.akeo.ie/) is required to [update/replace the existing DFU driver](https://github.com/benlye/flash-multi/blob/master/doc/Troubleshooting.md#re-installing-the-maple-dfu-device-drivers).