### PR TITLE
implement datasheet errata note

### DIFF
--- a/Multiprotocol/SX1276_SPI.ino
+++ b/Multiprotocol/SX1276_SPI.ino
@@ -42,6 +42,41 @@ uint8_t SX1276_Reset()
     return 0;
 }
 
+bool SX1276_DetectChip() //to be called after reset, verfies the chip has been detected
+{
+  #define MaxAttempts 5
+  uint8_t i = 0;
+  bool chipFound = false;
+  while ((i < MaxAttempts) && !chipFound)
+  {
+    uint8_t ChipVersion = SX1276_ReadReg(0x42);
+    if (ChipVersion == 0x12)
+    {
+      debugln("SX1276 reg version=%d", ChipVersion);
+      chipFound = true;
+    }
+    else
+    {
+      debug("SX1276 not found! attempts: ");
+      debug(i + 1);
+      debug(" of ");
+      debug(MaxAttempts);
+      debugln(" SX1276 reg version=%d", ChipVersion);
+      i++;
+    }
+  }
+  if (!chipFound)
+  {
+    debugln("SX1276 not detected!!!");
+    return false;
+  }
+  else
+  {
+    debugln("Found SX1276 Device!");
+    return true;
+  }
+}
+
 void SX1276_SetTxRxMode(uint8_t mode)
 {
 	#ifdef SX1276_TXEN_pin

--- a/Multiprotocol/SX1276_SPI.ino
+++ b/Multiprotocol/SX1276_SPI.ino
@@ -42,41 +42,6 @@ uint8_t SX1276_Reset()
     return 0;
 }
 
-bool SX1276_DetectChip() //to be called after reset, verfies the chip has been detected
-{
-  #define MaxAttempts 5
-  uint8_t i = 0;
-  bool chipFound = false;
-  while ((i < MaxAttempts) && !chipFound)
-  {
-    uint8_t ChipVersion = SX1276_ReadReg(0x42);
-    if (ChipVersion == 0x12)
-    {
-      debugln("SX1276 reg version=%d", ChipVersion);
-      chipFound = true;
-    }
-    else
-    {
-      debug("SX1276 not found! attempts: ");
-      debug(i + 1);
-      debug(" of ");
-      debug(MaxAttempts);
-      debugln(" SX1276 reg version=%d", ChipVersion);
-      i++;
-    }
-  }
-  if (!chipFound)
-  {
-    debugln("SX1276 not detected!!!");
-    return false;
-  }
-  else
-  {
-    debugln("Found SX1276 Device!");
-    return true;
-  }
-}
-
 void SX1276_SetTxRxMode(uint8_t mode)
 {
 	#ifdef SX1276_TXEN_pin

--- a/Multiprotocol/SX1276_SPI.ino
+++ b/Multiprotocol/SX1276_SPI.ino
@@ -103,6 +103,16 @@ void SX1276_ConfigModem1(uint8_t bandwidth, uint8_t coding_rate, bool implicit_h
 	data = data | implicit_header_mode;
 
 	SX1276_WriteReg(SX1276_1D_MODEMCONFIG1, data);
+
+  if (bandwidth == SX1276_MODEM_CONFIG1_BW_500KHZ) //datasheet errata reconmendation http://caxapa.ru/thumbs/972894/SX1276_77_8_ErrataNote_1.1_STD.pdf
+  {
+    SX1276_WriteReg(0x36, 0x02);
+    SX1276_WriteReg(0x3a, 0x64);
+  }
+  else
+  {
+    SX1276_WriteReg(0x36, 0x03);
+  }
 }
 
 void SX1276_ConfigModem2(uint8_t spreading_factor, bool tx_continuous_mode, bool rx_payload_crc_on)


### PR DESCRIPTION
Some of the default settings of the LoRa modem should be manually modified to optimize the sensitivity of the product when the bandwidth is set to 500 kHz.

![image](https://user-images.githubusercontent.com/22009829/84686029-8c220000-af7e-11ea-88ba-9509cb2334b5.png)

http://caxapa.ru/thumbs/972894/SX1276_77_8_ErrataNote_1.1_STD.pdf

Also added SX1276_DetectChip() method which can be useful for debugging. 