### PR TITLE
Adds SX1276_DetectChip() function

### DIFF
--- a/Multiprotocol/SX1276_SPI.ino
+++ b/Multiprotocol/SX1276_SPI.ino
@@ -42,6 +42,41 @@ uint8_t SX1276_Reset()
     return 0;
 }
 
+bool SX1276_DetectChip() //to be called after reset, verfies the chip has been detected
+{
+  #define MaxAttempts 5
+  uint8_t i = 0;
+  bool chipFound = false;
+  while ((i < MaxAttempts) && !chipFound)
+  {
+    uint8_t ChipVersion = SX1276_ReadReg(0x42);
+    if (ChipVersion == 0x12)
+    {
+      debugln("SX1276 reg version=%d", ChipVersion);
+      chipFound = true;
+    }
+    else
+    {
+      debug("SX1276 not found! attempts: ");
+      debug(i + 1);
+      debug(" of ");
+      debug(MaxAttempts);
+      debugln(" SX1276 reg version=%d", ChipVersion);
+      i++;
+    }
+  }
+  if (!chipFound)
+  {
+    debugln("SX1276 not detected!!!");
+    return false;
+  }
+  else
+  {
+    debugln("Found SX1276 Device!");
+    return true;
+  }
+}
+
 void SX1276_SetTxRxMode(uint8_t mode)
 {
 	#ifdef SX1276_TXEN_pin

--- a/Multiprotocol/SX1276_SPI.ino
+++ b/Multiprotocol/SX1276_SPI.ino
@@ -57,11 +57,9 @@ bool SX1276_DetectChip() //to be called after reset, verfies the chip has been d
     }
     else
     {
-      debug("SX1276 not found! attempts: ");
-      debug(i + 1);
+      debug("SX1276 not found! attempts: %d", i);
       debug(" of ");
-      debug(MaxAttempts);
-      debugln(" SX1276 reg version=%d", ChipVersion);
+      debugln("%d SX1276 reg version=%d", MaxAttempts, ChipVersion);
       i++;
     }
   }


### PR DESCRIPTION
Works by testing for 0x12 match in version reg 0x42.
Not 100% needed, but nice for debugging. 