### PR TITLE
C8 MCU flash size check

### DIFF
--- a/Multiprotocol/Multiprotocol.h
+++ b/Multiprotocol/Multiprotocol.h
@@ -726,6 +726,15 @@ enum {
 #define DSM_RX_EEPROM_OFFSET	877		// (4) TX ID + format, 5 bytes, end is 882
 //#define CONFIG_EEPROM_OFFSET 	882		// Current configuration of the multimodule
 
+/* STM32 Flash Size */
+#ifndef DISABLE_FLASH_SIZE_CHECK
+	#ifdef MCU_STM32F103C8
+		#define MCU_EXPECTED_FLASH_SIZE 64	// STM32F103C8 has 64KB of flash space
+	#else
+		#define MCU_EXPECTED_FLASH_SIZE 128	// STM32F103CB has 128KB of flash space
+	#endif
+#endif
+
 //****************************************
 //*** MULTI protocol serial definition ***
 //****************************************

--- a/Multiprotocol/Multiprotocol.ino
+++ b/Multiprotocol/Multiprotocol.ino
@@ -374,7 +374,7 @@ void setup()
 		#ifndef DISABLE_FLASH_SIZE_CHECK
 			unsigned short *flashSize = (unsigned short *) (0x1FFFF7E0);// Address register 
 			debugln("Module Flash size: %dKB",(int)(*flashSize & 0xffff));
-			if((int)(*flashSize & 0xffff) < 128)  // Not supported by this project
+			if((int)(*flashSize & 0xffff) < MCU_EXPECTED_FLASH_SIZE)  // Not supported by this project
 				while (true) { //SOS
 					for(uint8_t i=0; i<3;i++)
 					{


### PR DESCRIPTION
Updates the flash size check to set the expected size according to the MCU.  Allows the user to compile and use firmware on a C8 MCU using the new board package, without completely disabling the flash size check.