### PR TITLE
Fix compiler errors when telemetry is disabled

### DIFF
--- a/Multiprotocol/OMP_cc2500.ino
+++ b/Multiprotocol/OMP_cc2500.ino
@@ -142,18 +142,20 @@ static void __attribute__((unused)) OMP_initialize_txid()
 	#endif
 }
 
-static void __attribute__((unused)) OMP_Send_Telemetry(uint8_t v)
-{
-	v_lipo1=v;
-	telemetry_counter++;	//LQI
-	telemetry_link=1;
-	if(telemetry_lost)
+#ifdef OMP_HUB_TELEMETRY
+	static void __attribute__((unused)) OMP_Send_Telemetry(uint8_t v)
 	{
-		telemetry_lost = 0;
-		packet_count = 100;
-		telemetry_counter = 100;
+		v_lipo1=v;
+		telemetry_counter++;	//LQI
+		telemetry_link=1;
+		if(telemetry_lost)
+		{
+			telemetry_lost = 0;
+			packet_count = 100;
+			telemetry_counter = 100;
+		}
 	}
-}
+#endif
 
 enum {
 	OMP_BIND		= 0x00,

--- a/Multiprotocol/Validate.h
+++ b/Multiprotocol/Validate.h
@@ -344,6 +344,7 @@
 	#undef OMP_HUB_TELEMETRY
 	#undef RLINK_HUB_TELEMETRY
 	#undef DSM_RX_CYRF6936_INO
+	#undef DSM_FWD_PGM
 #else
 	#if defined(MULTI_TELEMETRY) && defined(MULTI_STATUS)
 		#error You should choose either MULTI_TELEMETRY or MULTI_STATUS but not both.


### PR DESCRIPTION
Not sure if this will be right, but thought I'd have a go :)

* Disable DSM_FWD_PGM if telemetry is disabled
* Only define OMP_Send_Telemetry if OMP telemetry is enabled
