### PR TITLE
Add STM32 EEPROM initialization at startup

### DIFF
--- a/Multiprotocol/Multiprotocol.ino
+++ b/Multiprotocol/Multiprotocol.ino
@@ -401,6 +401,17 @@ void setup()
 					delay(1000);
 				}
 		#endif
+
+		// Initialize the EEPROM
+		uint16_t eepromStatus = EEPROM.init();
+		debugln("EEPROM initialized: %d",eepromStatus);
+
+		// If there was no valid EEPROM page the EEPROM is corrupt or uninitialized and should be formatted
+		if( eepromStatus == EEPROM_NO_VALID_PAGE )
+		{
+			EEPROM.format();
+			debugln("No valid EEPROM page, EEPROM formatted");
+		}
 	#else
 		//ATMEGA328p
 		// all inputs


### PR DESCRIPTION
Calls the `EEPROM.init` function at startup to check/initialize the EEPROM.  If there is no valid EEPROM page the EEPROM is formatted by calling `EEPROM.format`.

Solves the problem discovered in #473 where bad data in the EEPROM section of flash causes EEPROM reads and writes to fail.

Normal first startup with no EEPROM data:
```
Multiprotocol version: 1.3.1.78
EEPROM initialized: 0
Protocol selection switch reads as 0
Generated ID from STM32 UUID
Module Id: 73739e23
Init complete
```

Normal subsequent startup with valid EEPROM data:
```
Multiprotocol version: 1.3.1.77
EEPROM initialized: 0
Protocol selection switch reads as 0
Read ID from EEPROM
Module Id: 73739e23
Init complete
```

Startup with invalid EEPROM data (status 171 = no valid EEPROM page):
```
Multiprotocol version: 1.3.1.77
EEPROM initialized: 171
No valid EEPROM page, EEPROM formatted
Protocol selection switch reads as 0
Generated ID from STM32 UUID
Module Id: 73739e23
Init complete
```

Subsequent startups after EEPROM formatted:
```
Multiprotocol version: 1.3.1.77
EEPROM initialized: 0
Protocol selection switch reads as 0
Read ID from EEPROM
Module Id: 73739e23
Init complete
```