### PR TITLE
Pin arduino-cli version to 0.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ before_install:
 install:
   # Install Arduino CLI
   - mkdir ~/arduino-cli
-  - curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=~/arduino-cli sh;
+  - curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=~/arduino-cli sh -s 0.13.0;
   - export PATH=$PATH:$HOME/arduino-cli
 
   # Update the board url and package index


### PR DESCRIPTION
The latest version of arduino-cli doesn't seem to like our board packages.  Force the builds to use arduino-cli 0.13.0 until it is resolved.