### PR TITLE
Various fixes for CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ on:
     tags-ignore:
       - '**'
     paths:
+    - '.github/workflows/**'
+    - 'buildroot/bin/**'
     - 'Multiprotocol/**'
 
   # Trigger the workflow on pull requests to the master branch
@@ -17,6 +19,8 @@ on:
     branches:
       - master
     paths:
+    - '.github/workflows/**'
+    - 'buildroot/bin/**'
     - 'Multiprotocol/**'
 
   # Triggers the workflow on release creation
@@ -86,8 +90,22 @@ jobs:
           # Load the build functions
           source ./buildroot/bin/buildFunctions;  
           
+          # Get the version
+          getMultiVersion
+          echo "MULTI_VERSION=$(echo $MULTI_VERSION)" >> $GITHUB_ENV
+
           # Get all the protocols for this board
           getAllProtocols
+          echo "A7105_PROTOCOLS=$(echo $A7105_PROTOCOLS)" >> $GITHUB_ENV
+          echo "CC2500_PROTOCOLS=$(echo $CC2500_PROTOCOLS)" >> $GITHUB_ENV
+          echo "CYRF6936_PROTOCOLS=$(echo $CYRF6936_PROTOCOLS)" >> $GITHUB_ENV
+          echo "NRF24L01_PROTOCOLS=$(echo $NRF24L01_PROTOCOLS)" >> $GITHUB_ENV
+          echo "SX1276_PROTOCOLS=$(echo $SX1276_PROTOCOLS)" >> $GITHUB_ENV
+          echo "ALL_PROTOCOLS=$(echo $ALL_PROTOCOLS)" >> $GITHUB_ENV
+
+          # Get all the RF modules for this board
+          getAllRFModules
+          echo "ALL_RFMODULES=$(echo $ALL_RFMODULES)" >> $GITHUB_ENV
 
           # Disable CHECK_FOR_BOOTLOADER when not needed
           if [[ "$BOARD" == "multi4in1:avr:multiatmega328p:bootloader=none" ]]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,5 +185,5 @@ jobs:
         if: env.HAVE_FILES == 'true'
         uses: actions/upload-artifact@v2
         with:
-          name: build-artifacts
+          name: multi-test-build
           path: ./binaries/

--- a/buildroot/bin/buildFunctions
+++ b/buildroot/bin/buildFunctions
@@ -54,7 +54,6 @@ buildProtocol() {
 }
 
 buildEachProtocol() {
-    getAllProtocols;
     exitcodesum=0;
     for PROTOCOL in $ALL_PROTOCOLS ; do 
         printf "\e[33;1mBuilding $PROTOCOL\e[0m\n"; 
@@ -74,7 +73,6 @@ buildRFModule() {
 }
 
 buildEachRFModule() {
-    getAllRFModules;
     exitcodesum=0;
     for RFMODULE in $ALL_RFMODULES; do
         printf "\e[33;1mBuilding $RFMODULE\e[0m\n";

--- a/buildroot/bin/build_release_avr_noboot
+++ b/buildroot/bin/build_release_avr_noboot
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 source ./buildroot/bin/buildFunctions;
-getMultiVersion;
 exitcode=0;
 
 printf "\e[33;1mBuilding multi-avr-usbasp-aetr-A7105-inv-v$MULTI_VERSION.bin\e[0m\n";
@@ -15,8 +14,9 @@ mv build/Multiprotocol.ino.bin ./binaries/multi-avr-usbasp-aetr-A7105-inv-v$MULT
 printf "\e[33;1mBuilding multi-avr-usbasp-aetr-CC2500-inv-v$MULTI_VERSION.bin\e[0m\n";
 opt_disable $ALL_PROTOCOLS;
 opt_enable $CC2500_PROTOCOLS;
-opt_disable HITEC_CC2500_INO REDPINE_CC2500_INO SKYARTEC_CC2500_INO SCANNER_CC2500_INO;
+opt_disable HITEC_CC2500_INO REDPINE_CC2500_INO OMP_CC2500_INO SKYARTEC_CC2500_INO SCANNER_CC2500_INO;
 buildMulti;
+exitcode=$((exitcode+$?));
 mv build/Multiprotocol.ino.bin ./binaries/multi-avr-usbasp-aetr-CC2500-inv-v$MULTI_VERSION.bin;
 
 printf "\e[33;1mBuilding multi-avr-usbasp-aetr-CYRF6936-inv-v$MULTI_VERSION.bin\e[0m\n";

--- a/buildroot/bin/build_release_avr_optiboot
+++ b/buildroot/bin/build_release_avr_optiboot
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 source ./buildroot/bin/buildFunctions;
-getMultiVersion;
 exitcode=0;
 
 printf "\e[33;1mBuilding multi-avr-txflash-aetr-A7105-inv-v$MULTI_VERSION.bin\e[0m\n";
@@ -15,7 +14,7 @@ mv build/Multiprotocol.ino.bin ./binaries/multi-avr-txflash-aetr-A7105-inv-v$MUL
 printf "\e[33;1mBuilding multi-avr-txflash-aetr-CC2500-inv-v$MULTI_VERSION.bin\e[0m\n";
 opt_disable $ALL_PROTOCOLS;
 opt_enable $CC2500_PROTOCOLS;
-opt_disable HITEC_CC2500_INO REDPINE_CC2500_INO SKYARTEC_CC2500_INO SCANNER_CC2500_INO;
+opt_disable HITEC_CC2500_INO REDPINE_CC2500_INO OMP_CC2500_INO SKYARTEC_CC2500_INO SCANNER_CC2500_INO;
 buildMulti;
 exitcode=$((exitcode+$?));
 mv build/Multiprotocol.ino.bin ./binaries/multi-avr-txflash-aetr-CC2500-inv-v$MULTI_VERSION.bin;

--- a/buildroot/bin/build_release_orx
+++ b/buildroot/bin/build_release_orx
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 source ./buildroot/bin/buildFunctions;
-getMultiVersion;
 exitcode=0;
 
 printf "\e[33;1mBuilding multi-orangerx-aetr-green-inv-v$MULTI_VERSION.bin\e[0m\n";

--- a/buildroot/bin/build_release_stm32f1_native_debug
+++ b/buildroot/bin/build_release_stm32f1_native_debug
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 source ./buildroot/bin/buildFunctions;
-getMultiVersion;
 exitcode=0;
 
 printf "\e[33;1mBuilding multi-stm-xn297dump-usbdebug-v$MULTI_VERSION.bin\e[0m\n";

--- a/buildroot/bin/build_release_stm32f1_no_debug
+++ b/buildroot/bin/build_release_stm32f1_no_debug
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 source ./buildroot/bin/buildFunctions;
-getMultiVersion;
 exitcode=0;
 
 printf "\e[33;1mBuilding multi-stm-serial-aetr-v$MULTI_VERSION.bin\e[0m\n";

--- a/buildroot/bin/build_release_stm32f1_serial_debug
+++ b/buildroot/bin/build_release_stm32f1_serial_debug
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 source ./buildroot/bin/buildFunctions;
-getMultiVersion;
 exitcode=0;
 
 printf "\e[33;1mBuilding multi-stm-xn297dump-ftdidebug-v$MULTI_VERSION.bin\e[0m\n";

--- a/buildroot/bin/build_release_stm32f1_t18int
+++ b/buildroot/bin/build_release_stm32f1_t18int
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 source ./buildroot/bin/buildFunctions;
-getMultiVersion;
 exitcode=0;
 
 printf "\e[33;1mBuilding multi-t18int-aetr-v$MULTI_VERSION.bin\e[0m\n";


### PR DESCRIPTION
* Run tests if the build scripts are modified (as well as if the FW source is modified)
* Fix AVR release builds so that correct protocols are included/excluded
* Fix AVR no-bootloader CC2500 build so that failures bubble up
* Exclude OMP from the AVR CC2500 build so that it fits (excluded protocols are now Hitec, Redpine, OMP, Skyartec, and Scanner)