### PR TITLE
Fix EEPROM address variable types for AFHDS 2A and Hott

### DIFF
--- a/Multiprotocol/AFHDS2A_a7105.ino
+++ b/Multiprotocol/AFHDS2A_a7105.ino
@@ -298,7 +298,7 @@ uint16_t ReadAFHDS2A()
 				A7105_ReadData(AFHDS2A_RXPACKET_SIZE);
 				if(packet[0] == 0xbc && packet[9] == 0x01)
 				{
-					uint8_t addr;
+					uint16_t addr;
 					if(RX_num<16)
 						addr=AFHDS2A_EEPROM_OFFSET+RX_num*4;
 					else
@@ -433,7 +433,7 @@ uint16_t initAFHDS2A()
 	{
 		phase = AFHDS2A_DATA_INIT;
 		//Read RX ID from EEPROM based on RX_num, RX_num must be uniq for each RX
-		uint8_t addr;
+		uint16_t addr;
 		if(RX_num<16)
 			addr=AFHDS2A_EEPROM_OFFSET+RX_num*4;
 		else

--- a/Multiprotocol/HOTT_cc2500.ino
+++ b/Multiprotocol/HOTT_cc2500.ino
@@ -159,7 +159,7 @@ static void __attribute__((unused)) HOTT_init()
 	else
 	{
 		memcpy(&packet[40],rx_tx_addr,5);
-		uint8_t addr=HOTT_EEPROM_OFFSET+RX_num*5;
+		uint16_t addr=HOTT_EEPROM_OFFSET+RX_num*5;
 		debug("RXID: ");
 		for(uint8_t i=0;i<5;i++)
 		{
@@ -380,7 +380,7 @@ uint16_t ReadHOTT()
 						for(uint8_t i=0;i<HOTT_RX_PACKET_LEN;i++)
 							debug(" %02X", packet_in[i]);
 						debugln("");
-						uint8_t addr=HOTT_EEPROM_OFFSET+RX_num*5;
+						uint16_t addr=HOTT_EEPROM_OFFSET+RX_num*5;
 						for(uint8_t i=0; i<5; i++)
 							eeprom_write_byte((EE_ADDR)(addr+i),packet_in[5+i]);
 						BIND_DONE;

--- a/Multiprotocol/Multiprotocol.h
+++ b/Multiprotocol/Multiprotocol.h
@@ -19,7 +19,7 @@
 #define VERSION_MAJOR		1
 #define VERSION_MINOR		3
 #define VERSION_REVISION	1
-#define VERSION_PATCH_LEVEL	93
+#define VERSION_PATCH_LEVEL	94
 
 //******************
 // Protocols


### PR DESCRIPTION
Fixes the problem where AFHDS 2A RX binds are not stored if the RX number is higher than 17, and seemingly (although untested) the same problem for Hott.

* AFHDS 2A RX numbers >17 result in EEPROM addresses >255, which overflowed the uint8 address variable
* All Hott RX EEPROM addresses are >255, also overflowing the uint8 address variable