### PR TITLE
Add release builds for 64KB CC2500-only module

### DIFF
--- a/buildroot/bin/buildFunctions
+++ b/buildroot/bin/buildFunctions
@@ -98,6 +98,8 @@ buildReleaseFiles(){
         build_release_stm32f1_serial_debug;
     elif [[ "$BOARD" == "multi4in1:STM32F1:multi5in1t18int" ]]; then
         build_release_stm32f1_t18int;
+    elif [[ "$BOARD" == "multi4in1:STM32F1:multistm32f103c8:debug_option=none" ]]; then
+        build_release_stm32f1_64k;
     else
       printf "No release files for this board.";
     fi

--- a/buildroot/bin/build_release_stm32f1_64k
+++ b/buildroot/bin/build_release_stm32f1_64k
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+source ./buildroot/bin/buildFunctions;
+exitcode=0;
+
+# CC2500-only 64Kb builds
+printf "\e[33;1mBuilding mm-stm-cc2500-64-aetr-v$MULTI_VERSION.bin\e[0m\n";
+opt_enable $ALL_PROTOCOLS;
+opt_disable IKEAANSLUTA_CC2500_INO;
+opt_disable ENABLE_PPM;
+opt_disable A7105_INSTALLED;
+opt_disable CYRF6936_INSTALLED;
+opt_disable NRF24L01_INSTALLED;
+opt_disable INVERT_TELEMETRY;
+buildMulti;
+exitcode=$((exitcode+$?));
+mv build/Multiprotocol.ino.bin ./binaries/mm-stm-cc2500-64-aetr-v$MULTI_VERSION.bin;
+
+printf "\e[33;1mBuilding mm-stm-cc2500-64-taer-v$MULTI_VERSION.bin\e[0m\n";
+opt_replace AETR TAER;
+buildMulti;
+exitcode=$((exitcode+$?));
+mv build/Multiprotocol.ino.bin ./binaries/mm-stm-cc2500-64-taer-v$MULTI_VERSION.bin;
+
+printf "\e[33;1mBuilding mm-stm-cc2500-64-reta-v$MULTI_VERSION.bin\e[0m\n";
+opt_replace TAER RETA;
+buildMulti;
+exitcode=$((exitcode+$?));
+mv build/Multiprotocol.ino.bin ./binaries/mm-stm-cc2500-64-reta-v$MULTI_VERSION.bin;
+
+exit $exitcode;


### PR DESCRIPTION
Adds the three channel order builds for a CC2500-only module with the STM32F103C8 MCU, like we're seeing in some TX12 radios.  With all CC2500 protocols except IKEA the build is at 53172 bytes (96%).

I still need to update the downloads page to show / filter them properly.