### PR TITLE
Graupner HoTT protocol / added packet_in[14] to transfer HoTT device warnings to OpenTx

### DIFF
--- a/Multiprotocol/HOTT_cc2500.ino
+++ b/Multiprotocol/HOTT_cc2500.ino
@@ -390,7 +390,7 @@ uint16_t HOTT_callback()
 						{	//Telemetry
 							// [0..4] = TXID
 							// [5..9] = RXID
-							// [10] = 0x40 bind, 0x00 normal, 0x80 config menu
+							// [10] = holds warnings issued by hott devices
 							// [11] = telmetry pages. For sensors 0x00 to 0x04, for config mennu 0x00 to 0x12.
 							// Normal telem page 0 = 0x55, 0x32, 0x38, 0x55, 0x64, 0x32, 0xD0, 0x07, 0x00, 0x55
 							//   Page 0 [12] = [21] = [15]
@@ -400,7 +400,7 @@ uint16_t HOTT_callback()
 							//   Page 0 [16] = RX_LQI in %
 							//   Page 0 [17] = RX_Voltage Min*10 in V
 							//   Page 0 [18,19] = [19]<<8+[18]=max lost packet time in ms, max value seems 2s=0x7D0
-							//   Page 0 [20] = 0x00 ??
+							//   Page 0 [20] = rx events
 							//
 							// Config menu consists of the different telem pages put all together
 							//   Page X [12] = seems like all the telem pages with the same value are going together to make the full config menu text. Seen so far 'a', 'b', 'c', 'd' 
@@ -412,6 +412,7 @@ uint16_t HOTT_callback()
 							// Reduce telemetry to 14 bytes
 							packet_in[0]= packet_in[HOTT_RX_PACKET_LEN];
 							packet_in[1]= TX_LQI;
+							uint8_t hott_warnings = packet_in[10];						// save warnings from hott devices
 							bool send_telem=true;
 							HOTT_sensor_seq++;											// Increment RX sequence counter
 							if(packet[29] & 1)
@@ -464,6 +465,7 @@ uint16_t HOTT_callback()
 								packet_in[i-8]=packet_in[i];
 								debug(" %02X",packet_in[i]);
 							}
+							packet_in[14] = hott_warnings;								// restore saved warnings from hott devices
 							debugln("");
 							if(send_telem)
 								telemetry_link=2;

--- a/Multiprotocol/Telemetry.ino
+++ b/Multiprotocol/Telemetry.ino
@@ -309,8 +309,8 @@ static void multi_send_status()
 #ifdef HOTT_FW_TELEMETRY
 	void HOTT_short_frame()
 	{
-		multi_send_header(MULTI_TELEMETRY_HOTT, 14);
-		for (uint8_t i = 0; i < 14; i++)			// TX RSSI and TX LQI values followed by frame number and telemetry data
+		multi_send_header(MULTI_TELEMETRY_HOTT, 15);
+		for (uint8_t i = 0; i < 15; i++)			// TX RSSI and TX LQI values followed by frame number and telemetry data
 			Serial_write(packet_in[i]);
 	}
 #endif


### PR DESCRIPTION
This allows processing of HoTT device warnings by the OpenTX HoTT telemetry implemenation, please see the accompanying OpenTX PR https://github.com/opentx/opentx/pull/8767

Content:
This adds one additional byte to the data packet transferred to OpenTX. Please see attached file for details of data the byte content.

Implementation:
HOTT_cc2500.ino: incoming byte 10 holds the warning number issued by HoTT devices. This byte is saved and transferred as packet_in[14] to Opentx.
Telemetry.ino:
The number of bytes to be transferred to OpenTX is incremented from 13 to 14  

Attachments:
[HoTT warnings.txt](https://github.com/pascallanger/DIY-Multiprotocol-TX-Module/files/7467657/HoTT.warnings.txt)


