### PR TITLE
mention XK A800 in V911S/E119 details

### DIFF
--- a/Protocols_Details.md
+++ b/Protocols_Details.md
@@ -1312,7 +1312,7 @@ Rate: -100% High, +100% Low
 Models: WLtoys V911S, XK A110
 
 ### Sub_protocol E119 - *1*
-Models: Eachine E119, JJRC W01-J3, XK A220 P-40
+Models: Eachine E119, JJRC W01-J3, XK A220 P-40, newer XK A800
 
 CH1|CH2|CH3|CH4|CH5|CH6|CH7
 ---|---|---|---|---|---|---


### PR DESCRIPTION
I successfully tested the V911S/E119 protocol with my XK A800. With the changes contained in b740f4cd24d8a63637c5dddeccd074327caddfcd the 6G3D switching is working as well.