### PR TITLE
MultiConfig lua should also set and reset subProtocol

### DIFF
--- a/Lua_scripts/MultiConfig.lua
+++ b/Lua_scripts/MultiConfig.lua
@@ -48,6 +48,7 @@ local ModuleNumber = 0
 local ModuleType = ""
 local Module = {}
 local InitialProtocol = 0
+local InitialSubProtocol = 0
 
 function bitand(a, b)
     local result = 0
@@ -76,6 +77,7 @@ end
 local function Config_Release()
   --Set the protocol back to what it was
   Module.protocol = InitialProtocol
+  Module.subProtocol = InitialSubProtocol
   model.setModule(ModuleNumber, Module)
 
   --Stop requesting updates
@@ -422,7 +424,9 @@ local function Config_Init()
   --Get Module settings and set it to config protocol
   Module = model.getModule(ModuleNumber)
   InitialProtocol = Module.protocol
+  InitialSubProtocol = Module.subProtocol
   Module.protocol = 86
+  Module.subProtocol = 0
   model.setModule(ModuleNumber, Module)
   --pause while waiting for the module to switch to config
   for i = 0, 10, 1 do end


### PR DESCRIPTION
The MultiConfg Lua currently does not set the subProtocol, so in cases were the subprotocol is NOT 0 (i.e. Hitec Minima - protocol 39, sub-protocol 2) - the script correctly sets the to config mode (protocol 86) but does not set the subprotocol to 0, thus config mode is not successfully entered, resulting in a "No Config telemetry" error. As was documented here => https://github.com/EdgeTX/edgetx/issues/1722#issuecomment-1077708870

This now captures the initial subProtocol state, and restores it on exit. 

Tested on TX16S internal MPM using OpenTX 2.3.15 nightly and EdgeTX 2.7 nightly. 