### PR TITLE
Use devel boards in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,14 +40,14 @@ jobs:
       fail-fast: false
       matrix:
         board: [
-          "multi4in1:avr:multiatmega328p:bootloader=none", 
-          "multi4in1:avr:multiatmega328p:bootloader=optiboot", 
-          "multi4in1:avr:multixmega32d4", 
-          "multi4in1:STM32F1:multi5in1t18int", 
-          "multi4in1:STM32F1:multistm32f103cb:debug_option=none", 
-          "multi4in1:STM32F1:multistm32f103cb:debug_option=native", 
-          "multi4in1:STM32F1:multistm32f103cb:debug_option=ftdi", 
-          "multi4in1:STM32F1:multistm32f103c8:debug_option=none"
+          "multi4in1-devel:avr:multiatmega328p:bootloader=none", 
+          "multi4in1-devel:avr:multiatmega328p:bootloader=optiboot", 
+          "multi4in1-devel:avr:multixmega32d4", 
+          "multi4in1-devel:STM32F1:multi5in1t18int", 
+          "multi4in1-devel:STM32F1:multistm32f103cb:debug_option=none", 
+          "multi4in1-devel:STM32F1:multistm32f103cb:debug_option=native", 
+          "multi4in1-devel:STM32F1:multistm32f103cb:debug_option=ftdi", 
+          "multi4in1-devel:STM32F1:multistm32f103c8:debug_option=none"
         ]
 
     # Set the environment variables
@@ -67,15 +67,22 @@ jobs:
           echo "Event action: ${{ github.event.action }}"
           echo "Tag name: ${{ github.event.release.tag_name }}"
 
-          arduino-cli config init --additional-urls https://raw.githubusercontent.com/pascallanger/DIY-Multiprotocol-TX-Module-Boards/master/package_multi_4in1_board_index.json
+          arduino-cli config init --additional-urls https://raw.githubusercontent.com/pascallanger/DIY-Multiprotocol-TX-Module-Boards/master/package_multi_4in1_board_index.json,https://raw.githubusercontent.com/pascallanger/DIY-Multiprotocol-TX-Module-Boards/devel/source/package_multi_4in1_board_devel_index.json
           arduino-cli core update-index
           
-          if [[ "$BOARD" =~ "multi4in1:avr:" ]]; then
+          if [[ "$BOARD" =~ ":avr:" ]]; then
             arduino-cli core install arduino:avr;
+          fi
+
+          if [[ "$BOARD" =~ "multi4in1-devel:avr" ]]; then
+            arduino-cli core install multi4in1-devel:avr
+          elif [[ "$BOARD" =~ "multi4in1:avr" ]]; then
             arduino-cli core install multi4in1:avr
           fi
 
-          if [[ "$BOARD" =~ "multi4in1:STM32F1:" ]]; then
+          if [[ "$BOARD" =~ "multi4in1-devel:STM32F1:" ]]; then
+            arduino-cli core install multi4in1-devel:STM32F1
+          elif [[ "$BOARD" =~ "multi4in1:STM32F1:" ]]; then
             arduino-cli core install multi4in1:STM32F1
           fi
 
@@ -109,18 +116,18 @@ jobs:
           echo "ALL_RFMODULES=$(echo $ALL_RFMODULES)" >> $GITHUB_ENV
 
           # Disable CHECK_FOR_BOOTLOADER when not needed
-          if [[ "$BOARD" == "multi4in1:avr:multiatmega328p:bootloader=none" ]]; then
+          if [[ "$BOARD" =~ ":avr:multiatmega328p:bootloader=none" ]]; then
             opt_disable CHECK_FOR_BOOTLOADER;
           fi
 
           # Trim the build down for the Atmega328p board
-          if [[ "$BOARD" =~ "multi4in1:avr:multiatmega328p:" ]]; then
+          if [[ "$BOARD" =~ ":avr:multiatmega328p:" ]]; then
             opt_disable $ALL_PROTOCOLS
             opt_enable FRSKYX_CC2500_INO AFHDS2A_A7105_INO MJXQ_NRF24L01_INO DSM_CYRF6936_INO;
           fi
 
           # Trim the enabled protocols down for the STM32F103CB board with debugging or the STM32F103C8 board in general
-          if [[ "$BOARD" == "multi4in1:STM32F1:multistm32f103cb:debug_option=ftdi" ]] || [[ "$BOARD" == "multi4in1:STM32F1:multistm32f103cb:debug_option=native" ]] || [[ "$BOARD" =~ "multi4in1:STM32F1:multistm32f103c8" ]]; then
+          if [[ "$BOARD" =~ ":STM32F1:multistm32f103cb:debug_option=ftdi" ]] || [[ "$BOARD" =~ ":STM32F1:multistm32f103cb:debug_option=native" ]] || [[ "$BOARD" =~ ":STM32F1:multistm32f103c8" ]]; then
             opt_disable $ALL_PROTOCOLS;
             opt_enable FRSKYX_CC2500_INO AFHDS2A_A7105_INO MJXQ_NRF24L01_INO DSM_CYRF6936_INO;
           fi
@@ -133,7 +140,7 @@ jobs:
       - name: Build default configuration
         run: |
           # Skip the default build for boards where it's too large now
-          if [[ "$BOARD" == "multi4in1:STM32F1:multistm32f103cb:debug_option=none" ]] || [[ "$BOARD" == "multi4in1:STM32F1:multi5in1t18int" ]]; then
+          if [[ "$BOARD" =~ ":STM32F1:multistm32f103cb:debug_option=none" ]] || [[ "$BOARD" =~ ":STM32F1:multi5in1t18int" ]]; then
             printf "Not testing default build for $BOARD.";
           else
             source ./buildroot/bin/buildFunctions;

--- a/buildroot/bin/buildFunctions
+++ b/buildroot/bin/buildFunctions
@@ -9,11 +9,11 @@ getMultiVersion() {
 }
 
 getAllRFModules() {
-    if [[ "$BOARD" =~ "multi4in1:avr:multixmega32d4" ]]; then
+    if [[ "$BOARD" =~ ":avr:multixmega32d4" ]]; then
         ALL_RFMODULES=$(echo CYRF6936_INSTALLED);
-    elif [[ "$BOARD" =~ "multi4in1:avr:multiatmega328p:" ]]; then
+    elif [[ "$BOARD" =~ ":avr:multiatmega328p:" ]]; then
         ALL_RFMODULES=$(echo A7105_INSTALLED CYRF6936_INSTALLED CC2500_INSTALLED NRF24L01_INSTALLED);
-    elif [[ "$BOARD" =~ "multi4in1:STM32F1:" ]]; then
+    elif [[ "$BOARD" =~ ":STM32F1:" ]]; then
         ALL_RFMODULES=$(echo A7105_INSTALLED CYRF6936_INSTALLED CC2500_INSTALLED NRF24L01_INSTALLED SX1276_INSTALLED);
     fi
 }
@@ -26,11 +26,11 @@ getAllProtocols() {
     CCNRF_PROTOCOLS=$(sed -n 's/[\/\/]*[[:blank:]]*#define[[:blank:]]*\([[:alnum:]_]*_CCNRF_INO\)\(.*\)/\1/p' Multiprotocol/_Config.h)
     SX1276_PROTOCOLS=$(sed -n 's/[\/\/]*[[:blank:]]*#define[[:blank:]]*\([[:alnum:]_]*_SX1276_INO\)\(.*\)/\1/p' Multiprotocol/_Config.h)
 
-    if [[ "$BOARD" =~ "multi4in1:avr:multixmega32d4" ]]; then
+    if [[ "$BOARD" =~ ":avr:multixmega32d4" ]]; then
         ALL_PROTOCOLS=$(echo $CYRF6936_PROTOCOLS);
-    elif [[ "$BOARD" =~ "multi4in1:avr:multiatmega328p:" ]]; then
+    elif [[ "$BOARD" =~ ":avr:multiatmega328p:" ]]; then
         ALL_PROTOCOLS=$(echo $A7105_PROTOCOLS $CC2500_PROTOCOLS $CYRF6936_PROTOCOLS $NRF24L01_PROTOCOLS $CCNRF_PROTOCOLS);
-    elif [[ "$BOARD" =~ "multi4in1:STM32F1:" ]]; then
+    elif [[ "$BOARD" =~ ":STM32F1:" ]]; then
         ALL_PROTOCOLS=$(echo $A7105_PROTOCOLS $CC2500_PROTOCOLS $CYRF6936_PROTOCOLS $NRF24L01_PROTOCOLS $CCNRF_PROTOCOLS $SX1276_PROTOCOLS);
     fi
 }
@@ -84,21 +84,21 @@ buildEachRFModule() {
 }
 
 buildReleaseFiles(){
-    if [[ "$BOARD" == "multi4in1:avr:multixmega32d4" ]]; then
+    if [[ "$BOARD" =~ ":avr:multixmega32d4" ]]; then
         build_release_orx;
-    elif [[ "$BOARD" == "multi4in1:avr:multiatmega328p:bootloader=none" ]]; then
+    elif [[ "$BOARD" =~ ":avr:multiatmega328p:bootloader=none" ]]; then
         build_release_avr_noboot;
-    elif [[ "$BOARD" == "multi4in1:avr:multiatmega328p:bootloader=optiboot" ]]; then
+    elif [[ "$BOARD" =~ ":avr:multiatmega328p:bootloader=optiboot" ]]; then
         build_release_avr_optiboot;
-    elif [[ "$BOARD" == "multi4in1:STM32F1:multistm32f103cb:debug_option=none" ]]; then
+    elif [[ "$BOARD" =~ ":STM32F1:multistm32f103cb:debug_option=none" ]]; then
         build_release_stm32f1_no_debug;
-    elif [[ "$BOARD" == "multi4in1:STM32F1:multistm32f103cb:debug_option=native" ]]; then
+    elif [[ "$BOARD" =~ ":STM32F1:multistm32f103cb:debug_option=native" ]]; then
         build_release_stm32f1_native_debug;
-    elif [[ "$BOARD" == "multi4in1:STM32F1:multistm32f103cb:debug_option=ftdi" ]]; then
+    elif [[ "$BOARD" =~ ":STM32F1:multistm32f103cb:debug_option=ftdi" ]]; then
         build_release_stm32f1_serial_debug;
-    elif [[ "$BOARD" == "multi4in1:STM32F1:multi5in1t18int" ]]; then
+    elif [[ "$BOARD" =~ ":STM32F1:multi5in1t18int" ]]; then
         build_release_stm32f1_t18int;
-    elif [[ "$BOARD" == "multi4in1:STM32F1:multistm32f103c8:debug_option=none" ]]; then
+    elif [[ "$BOARD" =~ ":STM32F1:multistm32f103c8:debug_option=none" ]]; then
         build_release_stm32f1_64k;
     else
       printf "No release files for this board.";


### PR DESCRIPTION
This PR switches the CI process to use the 'devel' version of the MULTI Arduino board package.  The devel board uses a newer GCC compiler (gcc-8.3.1) which generates smaller firmware builds.  Once merged, all automated test and release builds will be done with the new board and compiler.

Switching the CI job to the devel board will enable us to get more testing with firmware built with the new compiler, ultimately enabling us to switch all builds over.