### PR TITLE
Update DSM FwdPrg.lua

### DIFF
--- a/Lua_scripts/DSM FwdPrg.lua
+++ b/Lua_scripts/DSM FwdPrg.lua
@@ -552,8 +552,8 @@ local function DSM_Init()
   RxName[0x001E]="AR631"
 
   --Text to be displayed -> need to use a file instead?
-  Text[0x0001]="On"
-  Text[0x0002]="Off"
+  Text[0x0001]="Off"
+  Text[0x0002]="On"
   Text[0x0003]="Inh"
   Text[0x0004]="Act"
   Text[0x000C]="Inhibit?" --?


### PR DESCRIPTION
Reversing 'Off' and 'On' text values in lines 555 and 556.  They are used in the SAFE and AS3X menu items in the DSM Forward Programming section, and they are functioning backwards. This will correct the issue. This is the fix for Issue #728