### PR TITLE
Fix builds by using older Arduino CLI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,10 +55,10 @@ jobs:
       BOARD: ${{ matrix.board }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       - name: Install Arduino CLI
-        uses: arduino/setup-arduino-cli@v1.1.1
+        uses: arduino/setup-arduino-cli@v1.1.2
         with:
           version: "0.32.2"
       
@@ -198,7 +198,7 @@ jobs:
 
       - name: 'Upload Artifacts'
         if: env.HAVE_FILES == 'true'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: multi-test-build
           path: ./binaries/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,8 @@ jobs:
       
       - name: Install Arduino CLI
         uses: arduino/setup-arduino-cli@v1.1.1
+        with:
+          version: "0.32.2"
       
       - name: Prepare build environment
         run: |


### PR DESCRIPTION
Workaround to the broken binary file signature problem #862 by using the previous version of Arduino CLI.