### PR TITLE
Add EU/LBT binaries to the build artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,16 +39,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        board: [
-          "multi4in1:avr:multiatmega328p:bootloader=none", 
-          "multi4in1:avr:multiatmega328p:bootloader=optiboot", 
-          "multi4in1:avr:multixmega32d4", 
-          "multi4in1:STM32F1:multi5in1t18int", 
-          "multi4in1:STM32F1:multistm32f103cb:debug_option=none", 
-          "multi4in1:STM32F1:multistm32f103cb:debug_option=native", 
-          "multi4in1:STM32F1:multistm32f103cb:debug_option=ftdi", 
-          "multi4in1:STM32F1:multistm32f103c8:debug_option=none"
-        ]
+        include:
+          - board: "multi4in1:avr:multiatmega328p:bootloader=none"
+            name: "ATmega328p"
+          - board: "multi4in1:avr:multiatmega328p:bootloader=optiboot"
+            name: "ATmega328p (Optiboot)"
+          - board: "multi4in1:avr:multixmega32d4"
+            name: "OrangeRX"
+          - board: "multi4in1:STM32F1:multistm32f103c8:debug_option=none"
+            name: "STM32F103 (64KB)"
+          - board: "multi4in1:STM32F1:multistm32f103cb:debug_option=none"
+            name: "STM32F103 (128KB)"
+          - board: "multi4in1:STM32F1:multistm32f103cb:debug_option=native"
+            name: "STM32F103 (128KB, USB Debugging)"
+          - board: "multi4in1:STM32F1:multistm32f103cb:debug_option=ftdi"
+            name: "STM32F103 (128KB, Serial Debugging)"
+          - board: "multi4in1:STM32F1:multi5in1t18int"
+            name: "T18 5-in-1 (128KB)"
+
+    # Set the build name using the friendly board name
+    name: ${{ matrix.name }}
 
     # Set the environment variables
     env:

--- a/buildroot/bin/build_release_stm32f1_64k
+++ b/buildroot/bin/build_release_stm32f1_64k
@@ -3,7 +3,7 @@
 source ./buildroot/bin/buildFunctions;
 exitcode=0;
 
-# CC2500-only 64Kb builds
+# CC2500-only 64Kb FCC builds
 printf "\e[33;1mBuilding mm-stm-cc2500-64-aetr-v$MULTI_VERSION.bin\e[0m\n";
 opt_enable $ALL_PROTOCOLS;
 opt_disable IKEAANSLUTA_CC2500_INO;
@@ -27,5 +27,25 @@ opt_replace TAER RETA;
 buildMulti;
 exitcode=$((exitcode+$?));
 mv build/Multiprotocol.ino.bin ./binaries/mm-stm-cc2500-64-reta-v$MULTI_VERSION.bin;
+
+# CC2500-only 64Kb LBT/EU builds
+printf "\e[33;1mBuilding mm-stm-cc2500-64-aetr-lbt-v$MULTI_VERSION.bin\e[0m\n";
+opt_replace RETA AETR;
+opt_add MULTI_EU;
+buildMulti;
+exitcode=$((exitcode+$?));
+mv build/Multiprotocol.ino.bin ./binaries/mm-stm-cc2500-64-aetr-lbt-v$MULTI_VERSION.bin;
+
+printf "\e[33;1mBuilding mm-stm-cc2500-64-taer-lbt-v$MULTI_VERSION.bin\e[0m\n";
+opt_replace AETR TAER;
+buildMulti;
+exitcode=$((exitcode+$?));
+mv build/Multiprotocol.ino.bin ./binaries/mm-stm-cc2500-64-taer-lbt-v$MULTI_VERSION.bin;
+
+printf "\e[33;1mBuilding mm-stm-cc2500-64-reta-lbt-v$MULTI_VERSION.bin\e[0m\n";
+opt_replace TAER RETA;
+buildMulti;
+exitcode=$((exitcode+$?));
+mv build/Multiprotocol.ino.bin ./binaries/mm-stm-cc2500-64-reta-lbt-v$MULTI_VERSION.bin;
 
 exit $exitcode;

--- a/buildroot/bin/build_release_stm32f1_no_debug
+++ b/buildroot/bin/build_release_stm32f1_no_debug
@@ -3,10 +3,6 @@
 source ./buildroot/bin/buildFunctions;
 exitcode=0;
 
-# Builds for the DIY 5-in-1 module exceed the 120KB working capacity of the STM32F103CB
-# To work around this we have to disable some protocols in the builds for this module
-#DIY_5IN1_DISABLED="MOULDKG_NRF24L01_INO";
-
 # Generic 4-in-1 FCC builds
 printf "\e[33;1mBuilding mm-stm-serial-aetr-v$MULTI_VERSION.bin\e[0m\n";
 opt_disable ENABLE_PPM;
@@ -50,7 +46,6 @@ mv build/Multiprotocol.ino.bin ./binaries/mm-stm-serial-reta-lbt-v$MULTI_VERSION
 printf "\e[33;1mBuilding mm-stm-5in1-aetr-v$MULTI_VERSION.bin\e[0m\n";
 opt_remove MULTI_EU;
 opt_replace RETA AETR;
-#opt_disable $DIY_5IN1_DISABLED;
 opt_enable SX1276_INSTALLED;
 buildMulti;
 exitcode=$((exitcode+$?));
@@ -73,7 +68,6 @@ printf "\e[33;1mBuilding mm-tlite5in1-aetr-v$MULTI_VERSION.bin\e[0m\n";
 opt_replace RETA AETR;
 opt_disable INVERT_TELEMETRY;
 opt_disable SX1276_INSTALLED;
-#opt_enable $DIY_5IN1_DISABLED;
 opt_enable "MULTI_5IN1_INTERNAL JP_TLite"
 buildMulti;
 exitcode=$((exitcode+$?));

--- a/buildroot/bin/build_release_stm32f1_no_debug
+++ b/buildroot/bin/build_release_stm32f1_no_debug
@@ -7,7 +7,7 @@ exitcode=0;
 # To work around this we have to disable some protocols in the builds for this module
 #DIY_5IN1_DISABLED="MOULDKG_NRF24L01_INO";
 
-# Generic 4-in-1 builds
+# Generic 4-in-1 FCC builds
 printf "\e[33;1mBuilding mm-stm-serial-aetr-v$MULTI_VERSION.bin\e[0m\n";
 opt_disable ENABLE_PPM;
 buildMulti;
@@ -26,8 +26,29 @@ buildMulti;
 exitcode=$((exitcode+$?));
 mv build/Multiprotocol.ino.bin ./binaries/mm-stm-serial-reta-v$MULTI_VERSION.bin;
 
+# Generic 4-in-1 LBT/EU builds
+printf "\e[33;1mBuilding mm-stm-serial-aetr-lbt-v$MULTI_VERSION.bin\e[0m\n";
+opt_replace RETA AETR;
+opt_add MULTI_EU;
+buildMulti;
+exitcode=$((exitcode+$?));
+mv build/Multiprotocol.ino.bin ./binaries/mm-stm-serial-aetr-lbt-v$MULTI_VERSION.bin;
+
+printf "\e[33;1mBuilding mm-stm-serial-taer-lbt-v$MULTI_VERSION.bin\e[0m\n";
+opt_replace AETR TAER;
+buildMulti;
+exitcode=$((exitcode+$?));
+mv build/Multiprotocol.ino.bin ./binaries/mm-stm-serial-taer-lbt-v$MULTI_VERSION.bin;
+
+printf "\e[33;1mBuilding mm-stm-serial-reta-lbt-v$MULTI_VERSION.bin\e[0m\n";
+opt_replace TAER RETA;
+buildMulti;
+exitcode=$((exitcode+$?));
+mv build/Multiprotocol.ino.bin ./binaries/mm-stm-serial-reta-lbt-v$MULTI_VERSION.bin;
+
 # DIY 5-in-1 builds
 printf "\e[33;1mBuilding mm-stm-5in1-aetr-v$MULTI_VERSION.bin\e[0m\n";
+opt_remove MULTI_EU;
 opt_replace RETA AETR;
 #opt_disable $DIY_5IN1_DISABLED;
 opt_enable SX1276_INSTALLED;
@@ -70,7 +91,7 @@ buildMulti;
 exitcode=$((exitcode+$?));
 mv build/Multiprotocol.ino.bin ./binaries/mm-tlite5in1-reta-v$MULTI_VERSION.bin;
 
-# CC2500-only builds
+# CC2500-only FCC builds
 printf "\e[33;1mBuilding mm-stm-cc2500-aetr-v$MULTI_VERSION.bin\e[0m\n";
 opt_replace RETA AETR;
 opt_disable "MULTI_5IN1_INTERNAL JP_TLite"
@@ -94,11 +115,32 @@ buildMulti;
 exitcode=$((exitcode+$?));
 mv build/Multiprotocol.ino.bin ./binaries/mm-stm-cc2500-reta-v$MULTI_VERSION.bin;
 
+# CC2500-only LBT/EU builds
+printf "\e[33;1mBuilding mm-stm-cc2500-aetr-lbt-v$MULTI_VERSION.bin\e[0m\n";
+opt_replace RETA AETR;
+opt_add MULTI_EU;
+buildMulti;
+exitcode=$((exitcode+$?));
+mv build/Multiprotocol.ino.bin ./binaries/mm-stm-cc2500-aetr-lbt-v$MULTI_VERSION.bin;
+
+printf "\e[33;1mBuilding mm-stm-cc2500-taer-lbt-v$MULTI_VERSION.bin\e[0m\n";
+opt_replace AETR TAER;
+buildMulti;
+exitcode=$((exitcode+$?));
+mv build/Multiprotocol.ino.bin ./binaries/mm-stm-cc2500-taer-lbt-v$MULTI_VERSION.bin;
+
+printf "\e[33;1mBuilding mm-stm-cc2500-reta-lbt-v$MULTI_VERSION.bin\e[0m\n";
+opt_replace TAER RETA;
+buildMulti;
+exitcode=$((exitcode+$?));
+mv build/Multiprotocol.ino.bin ./binaries/mm-stm-cc2500-reta-lbt-v$MULTI_VERSION.bin;
+
 # 4-in-1 PPM builds
 printf "\e[33;1mBuilding mm-stm-ppm-aetr-v$MULTI_VERSION.bin\e[0m\n";
 opt_enable A7105_INSTALLED;
 opt_enable CYRF6936_INSTALLED;
 opt_enable NRF24L01_INSTALLED;
+opt_remove MULTI_EU;
 opt_enable ENABLE_PPM;
 opt_disable ENABLE_SERIAL;
 opt_replace RETA AETR;

--- a/buildroot/bin/opt_remove
+++ b/buildroot/bin/opt_remove
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+SED=$(which gsed || which sed)
+
+eval "${SED} -i '/#define \b${1}/d' Multiprotocol/_Config.h"


### PR DESCRIPTION
* Adds EU/LBT binaries for three types of module (STM32F103CB 4in1, STM32F103CB CC2500, and STM32F103C8 CC2500)
* Gives each matrix build in the CI job a more intuitive name
* Cleanup some old commented-out lines