### PR TITLE
Disable SCANNER in CC2500 64kb builds

### DIFF
--- a/buildroot/bin/build_release_stm32f1_cc2500_64k
+++ b/buildroot/bin/build_release_stm32f1_cc2500_64k
@@ -5,8 +5,7 @@ exitcode=0;
 
 # CC2500-only 64Kb FCC builds
 printf "\e[33;1mBuilding mm-stm-cc2500-64-aetr-v$MULTI_VERSION.bin\e[0m\n";
-#opt_enable $ALL_PROTOCOLS;
-#opt_disable IKEAANSLUTA_CC2500_INO;
+opt_disable SCANNER_CC2500_INO;
 opt_disable ENABLE_PPM;
 opt_disable A7105_INSTALLED;
 opt_disable CYRF6936_INSTALLED;


### PR DESCRIPTION
Need to disable a protocol to get the release builds to fit on the 64kb CC2500 module. SCANNER is probably the least used.