### PR TITLE
chore(ci): bump setup-arduino-ci version to remove nodejs warning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install Arduino CLI
         uses: arduino/setup-arduino-cli@v2
         with:
-          version: "0.32.2"
+          version: "1.0.2"
       
       - name: Prepare build environment
         run: |
@@ -259,7 +259,7 @@ jobs:
       - name: Install Arduino CLI
         uses: arduino/setup-arduino-cli@v2
         with:
-          version: "0.32.2"
+          version: "1.0.2"
       
       - name: Prepare build environment
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Install Arduino CLI
-        uses: arduino/setup-arduino-cli@v1.1.2
+        uses: arduino/setup-arduino-cli@v2
         with:
           version: "0.32.2"
       
@@ -257,7 +257,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Install Arduino CLI
-        uses: arduino/setup-arduino-cli@v1.1.2
+        uses: arduino/setup-arduino-cli@v2
         with:
           version: "0.32.2"
       


### PR DESCRIPTION
Gets rid of the numerous  
> "The following actions uses Node.js version which is deprecated and will be forced to run on node20" 

warnings which are present in the action summary. And while it is still quite some time away, Github will be [ceasing support for NodeJS 16 actions by Spring 2024](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).

