### PR TITLE
Update SGF22_nrf24l01.ino

### DIFF
--- a/Multiprotocol/SGF22_nrf24l01.ino
+++ b/Multiprotocol/SGF22_nrf24l01.ino
@@ -37,10 +37,13 @@ Multiprotocol is distributed in the hope that it will be useful,
 #define SGF22_FLAG_VERTICAL		0xC0
 
 #define SGF22_J20_FLAG_HORIZONTAL  	0x80
+//#define SGF22_J20_FLAG_SPEED       0x01  // Up/Down trim, not implemented
 
 //packet[9]
 #define SGF22_FLAG_PHOTO		0x40	// #define SGF22_J20_FLAG_INVERT  0x40
 #define SGF22_FLAG_TRIMRESET		0x04
+
+#define SGF22_J20_FLAG_FIXHEIGHT  0x80
 
 static void __attribute__((unused)) SGF22_send_packet()
 {
@@ -73,7 +76,7 @@ static void __attribute__((unused)) SGF22_send_packet()
     		else if(Channel_data[CH5] > CHANNEL_MIN_COMMAND )
       			packet[8] |= ( sub_protocol == SGF22_J20 ? SGF22_J20_FLAG_HORIZONTAL : SGF22_FLAG_6G );     // CH5 0%, F22 & F22S - 6G mode, J20 - Horizontal mode
     		packet[9] = GET_FLAG(CH8_SW, SGF22_FLAG_PHOTO)  // F22: photo, press in throttle trim in the stock TX, J20: invert flight
-        		| GET_FLAG(CH10_SW, SGF22_FLAG_TRIMRESET);   // Both sticks down inwards in the stock TX
+        		| GET_FLAG(CH10_SW, ( sub_protocol == SGF22_J20 ? SGF22_J20_FLAG_FIXHEIGHT : SGF22_FLAG_TRIMRESET )) ;   // F22: Both sticks down inwards in the stock TX, J20: Altitude hold
 		packet[10] = 0x42;								// no fine tune
 		packet[11] = 0x10;								// no fine tune
 	}
@@ -140,7 +143,7 @@ static void __attribute__((unused)) SGF22_RF_init()
 {
 	XN297_Configure(XN297_CRCEN, XN297_SCRAMBLED, XN297_1M);
 	XN297_SetTXAddr((uint8_t*)"\xC7\x95\x3C\xBB\xA5", 5);
-	const uint8_t bind_chan[SGF22_J20 + 1] = {SGF22_BIND_RF_CHANNEL, SGF22_F22S_BIND_RF_CHANNEL, SGF22_J20_BIND_RF_CHANNEL}; 
+	const uint8_t bind_chan[] = {SGF22_BIND_RF_CHANNEL, SGF22_F22S_BIND_RF_CHANNEL, SGF22_J20_BIND_RF_CHANNEL}; 
 	XN297_RFChannel(bind_chan[sub_protocol]);	// Set bind channel
 }
 


### PR DESCRIPTION
Add "FixHeight(Altitude hold)"  flag to J20.

Change this web page 

https://github.com/pascallanger/DIY-Multiprotocol-TX-Module/blob/master/Protocols_Details.md#SGF22---97

Sub_protocol F22
Model: SG F22

SGF22: Mode -100% = 3D, 0% = 6G, 100% = Vertical

Sub_protocol F22S
Model: ParkTen F22S

F22S: Mode -100% = 3D, 0% = 6G _(take out 100% = Vertical since F22S does not do vertical)_

Sub_protocol J20
Model: KF700 J20

J20: Mode -100% = Gyro off, 0% = Horizontal, 100% = Vertical. CH8 - Invert, CH10 - Fix Height (Altitude hold)