### PR TITLE
Update readme and protocol detals with surface/air info

### DIFF
--- a/Protocols_Details.md
+++ b/Protocols_Details.md
@@ -6,7 +6,7 @@ Here are detailed descriptions of every supported protocols (sorted by RF module
  The Deviation project (on which this project was based) have a useful list of models and protocols [here](http://www.deviationtx.com/wiki/supported_models).
 
 ## Useful notes and definitions
-- **Surface and air protocols** - As the list of supported protocols grows even the STM32 ARM microcontroller cannot hold all of the protocols. Firmware available from the [Multi-Module](https://downloads.multi-module.org) website has been split into two groups, surfae and air. You can check which protocols are included in each of these groups in the [Validate.h](Multiprotocol/Validate.h) source file.
+- **Surface and air protocols** - As the list of supported protocols grows even the STM32 ARM microcontroller cannot hold all of the protocols. Firmware available from the [Multi-Module](https://downloads.multi-module.org) website has been split into two groups, surface "SFC" and air "AIR". You can check which protocols are included in each of these groups in the [Validate.h](Multiprotocol/Validate.h) source file.
 - **Channel Order** - The channel order assumed in all the documentation is AETR. You can change this in the compilation settings or by using a precompiled firmware. The module will take whatever input channel order you have choosen and will rearrange them to match the output channel order required by the selected protocol. 
 - **Channel ranges** - A radio output of -100%..0%..+100% will match on the selected protocol -100%,0%,+100%. No convertion needs to be done.
 - **Extended limits supported** - A channel range of -125%..+125% will be transmitted. Otherwise it will be truncated to -100%..+100%.

--- a/Protocols_Details.md
+++ b/Protocols_Details.md
@@ -6,6 +6,7 @@ Here are detailed descriptions of every supported protocols (sorted by RF module
  The Deviation project (on which this project was based) have a useful list of models and protocols [here](http://www.deviationtx.com/wiki/supported_models).
 
 ## Useful notes and definitions
+- **Surface and air protocols** - As the list of supported protocols grows even the STM32 ARM microcontroller cannot hold all of the protocols. Firmware available from the [Multi-Module](https://downloads.multi-module.org) website has been split into two groups, surfae and air. You can check which protocols are included in each of these groups in the [Validate.h](Multiprotocol/Validate.h) source file.
 - **Channel Order** - The channel order assumed in all the documentation is AETR. You can change this in the compilation settings or by using a precompiled firmware. The module will take whatever input channel order you have choosen and will rearrange them to match the output channel order required by the selected protocol. 
 - **Channel ranges** - A radio output of -100%..0%..+100% will match on the selected protocol -100%,0%,+100%. No convertion needs to be done.
 - **Extended limits supported** - A channel range of -125%..+125% will be transmitted. Otherwise it will be truncated to -100%..+100%.

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ For example, if you have no interest in binding your Tx to an model with and FrS
 
 ## **Choice 3:** Which protocols to upload to the MULTI-Module
 
-In the case of the ATmega328, the memory required by all the possible protocols exceeds the 32KB flash limit considerably. This means that you will need to make a choice of which protocols you will compile into your firmware.  Fortunately, the process of selecting and compiling is not too difficult and it is fully documented on the [Compiling and Programming](docs/Compiling.md) page.
+As the list of supported protocols grows even the STM32 ARM microcontroller cannot hold all of the protocols. You can select the protocols you need and complie your own firmware. Fortunately, the process of selecting and compiling is not too difficult and it is fully documented on the [Compiling and Programming](docs/Compiling.md) page. You can also download firmware from the [Multi-Module](https://downloads.multi-module.org) website. These firmware files have been split into two groups, surfae and air. You can check which protocols are included in each of these groups in the [Validate.h](Multiprotocol/Validate.h) source file.
 
-An alternative is to use a STM32 ARM microcontroller based module which can hold all the protocols.
+In the case of the ATmega328, the memory required by all the possible protocols exceeds the 32KB flash limit considerably. This means that you will need to make a choice of which protocols you will compile into your firmware.
 
 ## **Choice 4:** Choosing the type of interface between the MULTI-Module and your radio (PPM or Serial)
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ For example, if you have no interest in binding your Tx to an model with and FrS
 
 ## **Choice 3:** Which protocols to upload to the MULTI-Module
 
-As the list of supported protocols grows even the STM32 ARM microcontroller cannot hold all of the protocols. You can select the protocols you need and complie your own firmware. Fortunately, the process of selecting and compiling is not too difficult and it is fully documented on the [Compiling and Programming](docs/Compiling.md) page. You can also download firmware from the [Multi-Module](https://downloads.multi-module.org) website. These firmware files have been split into two groups, surfae and air. You can check which protocols are included in each of these groups in the [Validate.h](Multiprotocol/Validate.h) source file.
+As the list of supported protocols grows even the STM32 ARM microcontroller cannot hold all of the protocols. You can select the protocols you need and complie your own firmware. Fortunately, the process of selecting and compiling is not too difficult and it is fully documented on the [Compiling and Programming](docs/Compiling.md) page. You can also download firmware from the [Multi-Module](https://downloads.multi-module.org) website. These firmware files have been split into two groups, surface "SFC" and air "AIR". You can check which protocols are included in each of these groups in the [Validate.h](Multiprotocol/Validate.h) source file.
 
 In the case of the ATmega328, the memory required by all the possible protocols exceeds the 32KB flash limit considerably. This means that you will need to make a choice of which protocols you will compile into your firmware.
 


### PR DESCRIPTION
The protocols no longer fit on the STM32, it might be useful to update the README and Protocol Details to reflect this. It might also be helpful to mention the surface and air groups in the available compiled firmware on the Multi-Module website.