### PR TITLE
Add FX_QF012 subprotocol

### DIFF
--- a/Multiprotocol/FX_nrf24l01.ino
+++ b/Multiprotocol/FX_nrf24l01.ino
@@ -62,7 +62,7 @@ static void __attribute__((unused)) FX_send_packet()
 					trim_ch++;
 					if(trim_ch > 3) trim_ch = 0;
 				}
-				else // FX_Q560
+				else // FX_Q560, QF012
 					trim_ch = 0;
 			}
 		}
@@ -85,12 +85,16 @@ static void __attribute__((unused)) FX_send_packet()
 		val = trim_ch==0 ? 0x20 : (convert_channel_8b(trim_ch + CH6) >> 2);	// no trim on Throttle
 		packet[4] = val;			// Trim for channel x 0C..20..34
 		packet[5] = (trim_ch << 4)	// channel x << 4
-					| GET_FLAG(CH5_SW, 0x01)  // DR toggle swich: 0 small throw, 1 large throw / Q560 acrobatic
+					| GET_FLAG(CH5_SW, (sub_protocol == FX_QF012 ? 0x08 : 0x01))  // DR toggle swich: 0 small throw, 1 large throw / Q560 acrobatic / QF012 Special effects
 					// FX9630  =>0:6G small throw, 1:6G large throw, 2:3D
 					// QIDI-550=>0:3D, 1:6G, 2:Torque
+					// QF012=>0:beginner(6G), 1:mid(3D), 2:expert(Gyro off) 
 					| (Channel_data[CH6] < CHANNEL_MIN_COMMAND ? 0x00 : (Channel_data[CH6] > CHANNEL_MAX_COMMAND ? 0x04 : 0x02));
 		if(sub_protocol == FX_Q560)
 			packet[5] |= GET_FLAG(CH7_SW, 0x18);	// Q560 LED flag 0x10 conflicting with trim_ch... Corrected on new boards using 0x08 instead
+		else if (sub_protocol == FX_QF012) 
+      			packet[5] |=  GET_FLAG(CH7_SW, 0x40)  // QF012 invert flight
+                		    | GET_FLAG(CH8_SW, 0x80);  // QF012 Restore fine tunning midpoint
 	}
 	else // FX816 and FX620
 	{

--- a/Multiprotocol/Multi.txt
+++ b/Multiprotocol/Multi.txt
@@ -55,7 +55,7 @@
 55,Frsky_RX,Multi,CloneTX,EraseTX,CPPM
 56,AFHDS2A_RX,Multi,CPPM
 57,HoTT,Sync,No_Sync
-58,FX,816,620,9630,Q560
+58,FX,816,620,9630,Q560,QF012
 59,Bayang_RX,Multi,CPPM
 60,Pelikan,Pro,Lite,SCX24
 61,EazyRC

--- a/Multiprotocol/Multi_Protos.ino
+++ b/Multiprotocol/Multi_Protos.ino
@@ -187,7 +187,7 @@ const char STR_SUBTYPE_JJRC345[] =    "\x08""JJRC345\0""SkyTmblr";
 const char STR_SUBTYPE_MOULDKG[] =    "\x06""Analog""Digit\0";
 const char STR_SUBTYPE_KF606[] =      "\x06""KF606\0""MIG320""ZCZ50\0";
 const char STR_SUBTYPE_E129[] =       "\x04""E129""C186";
-const char STR_SUBTYPE_FX[] =         "\x04""816\0""620\0""9630""Q560";
+const char STR_SUBTYPE_FX[] =         "\x05""816\0 ""620\0 ""9630\0""Q560\0""QF012";
 const char STR_SUBTYPE_SGF22[] =      "\x04""F22\0""F22S""J20\0";
 const char STR_SUBTYPE_JIABAILE[] =   "\x04""Std\0""Gyro";
 #define NO_SUBTYPE		nullptr
@@ -344,7 +344,7 @@ const mm_protocol_definition multi_protocols[] = {
 		{PROTO_FUTABA,     STR_FUTABA,    STR_SUBTYPE_FUTABA,    1, OPTION_RFTUNE,  1, 1, SW_CC2500, SFHSS_init,      SFHSS_callback      },
 	#endif
 	#if defined(FX_NRF24L01_INO)
-		{PROTO_FX,         STR_FX,        STR_SUBTYPE_FX,        4, OPTION_NONE,    0, 0, SW_NRF,    FX_init,         FX_callback         },
+		{PROTO_FX,         STR_FX,        STR_SUBTYPE_FX,        5, OPTION_NONE,    0, 0, SW_NRF,    FX_init,         FX_callback         },
 	#endif
 	#if defined(FY326_NRF24L01_INO)
 		{PROTO_FY326,      STR_FY326,     STR_SUBTYPE_FY326,     2, OPTION_NONE,    0, 0, SW_NRF,    FY326_init,      FY326_callback      },

--- a/Multiprotocol/Multiprotocol.h
+++ b/Multiprotocol/Multiprotocol.h
@@ -491,6 +491,7 @@ enum FX
 	FX620			= 1,
     FX9630          = 2,
 	FX_Q560			= 3,
+	FX_QF012  = 4,
 };
 enum SGF22
 {

--- a/Multiprotocol/_Config.h
+++ b/Multiprotocol/_Config.h
@@ -700,6 +700,7 @@ const PPM_Parameters PPM_prot[14*NBR_BANKS]=	{
 		FX620
 		FX9630
 		Q560
+  		QF012
 	PROTO_FY326
 		FY326
 		FY319


### PR DESCRIPTION
This is for https://m.banggood.com/QF012-SBD-Dauntless-2_4GHz-4CH-350mm-Wingspan-6-Axis-Gyro-One-Key-Aerobatic-Brushless-EPP-Warbird-RC-Airplane-RTF-p-2028163.html

Add after 
https://github.com/pascallanger/DIY-Multiprotocol-TX-Module/blob/master/Protocols_Details.md#sub_protocol-q560---3

Sub_protocol QF012 - 4
Model: QF012 SBD Dauntless

CH1	CH2	CH3	CH4	CH5	CH6	CH7
A	E	T	R	FLIP	GYRO	Invert

Thanks.


