### PR TITLE
telemetry delay for FX protocol warnings

### DIFF
--- a/Multiprotocol/FX_nrf24l01.ino
+++ b/Multiprotocol/FX_nrf24l01.ino
@@ -282,7 +282,7 @@ uint16_t FX_callback()
 {
 	#ifdef FX_HUB_TELEMETRY
 		bool rx=false;
-		
+		static uint8_t telem_count = 0;
 		switch(phase)
 		{
 			case FX_DATA:
@@ -319,6 +319,8 @@ uint16_t FX_callback()
 					if(XN297_ReadPayload(packet_in, FX_QF012_RX_PAYLOAD_SIZE))
 					{//Good CRC
 						telemetry_link = 1;
+						telemetry_lost = 0;
+						telem_count = 0;
 						if ( sub_protocol == FX_BM26 )
 							v_lipo1 = packet_in[0] <  packet_in[2] ? 60:81;	// packets: AA 00 55 -> 55 00 AA = low voltage 3.7V
 						else
@@ -329,6 +331,19 @@ uint16_t FX_callback()
 						#endif
 					}
 					debugln();
+				}
+				if(telem_count > 4*63)				// Around 3.5 sec with no telemetry
+					telemetry_lost = 1;
+				else
+				{
+					telem_count++;
+					if(!telemetry_lost && (telem_count & 0x3F) == 0)
+					{// Should have received a telem packet but... Send telem to the radio to keep it alive
+						telemetry_link = 1;
+						#if 0
+							debugln("Miss");
+						#endif
+					}
 				}
 				phase++;
 				return FX9630_WRITE_TIME;
@@ -362,6 +377,7 @@ void FX_init()
 	bind_counter=FX_BIND_COUNT;
 	#ifdef FX_HUB_TELEMETRY
 		RX_RSSI = 100;		// Dummy value
+		telemetry_lost = 1;
 		phase = FX_DATA;
 	#endif
 }

--- a/Protocols_Details.md
+++ b/Protocols_Details.md
@@ -1871,7 +1871,7 @@ FX9630 and FX9603 Gyro: -100%=6G small throw, 0%=6G large throw, +100%=3D
 QIDI-550 Gyro: -100%=3D, 0%=6G, +100%=Torque
 
 ### Sub_protocol Q560 - *3*
-Model: QIDI-560
+Model: QIDI-560, QIDI-580 (Cirrus SR22)
 
 CH1|CH2|CH3|CH4|CH5|CH6|CH7
 ---|---|---|---|---|---|---
@@ -1879,7 +1879,8 @@ A|E|T|R|FLIP|GYRO|LEDs
 
 FLIP is a toggle channel meaning that -100% to +100% is a command and +100% to -100% is also a command
 
-Gyro: -100%=6G, 0%=3D+Gyro, +100%=3D
+QIDI-560 Gyro: -100%=6G, 0%=3D+Gyro, +100%=3D
+QIDI-580 Gyro: -100%=6G, 0%=6G+Inverted, +100%=3D+Gyro
 
 ### Sub_protocol QF012 - *4*
 Model: QF012 SBD Dauntless

--- a/Protocols_Details.md
+++ b/Protocols_Details.md
@@ -1879,8 +1879,8 @@ A|E|T|R|FLIP|GYRO|LEDs
 
 FLIP is a toggle channel meaning that -100% to +100% is a command and +100% to -100% is also a command
 
-QIDI-560 Gyro: -100%=6G, 0%=3D+Gyro, +100%=3D
-QIDI-580 Gyro: -100%=6G, 0%=6G+Inverted, +100%=3D+Gyro
+- GYRO QIDI-560: -100%=6G, 0%=3D+Gyro, +100%=3D
+- GYRO QIDI-580: -100%=6G, 0%=6G+Inverted, +100%=3D+Gyro
 
 ### Sub_protocol QF012 - *4*
 Model: QF012 SBD Dauntless


### PR DESCRIPTION
This PR duplicates the telemetry delay that was added to the V761 and SGF22 Protocols.
Eliminates the "telemetry lost", "telemetry recovered" warnings in OTX and ETX.

Tested using the latest master branch 1.3.4.55.
Using the Q560 sub protocol flying the Cirrus SR22 (QIDI-580) and 
Also the QF012 sub protocol flying the QF012 model (SBD Bomber).
Telemetry warnings originally 10 to 15 times per flight and dropped to zero after this PR. Battery telemetry still working.

Added a small update to Protocols_Details.md for the QIDI-580.

Thanks - Rich

