### PR TITLE
DSM: XPlus channels, Fix to support DSM CH16

### DIFF
--- a/Multiprotocol/DSM_cyrf6936.ino
+++ b/Multiprotocol/DSM_cyrf6936.ino
@@ -102,7 +102,7 @@ static void __attribute__((unused)) DSM_build_bind_packet()
 	if(sub_protocol==DSM_AUTO)
 		packet[11] = 12;
 	else
-		packet[11] = num_ch;				// DX5 DSMR sends 0x48...
+		packet[11] = min(num_ch,12); // DX5 DSMR sends 0x48...
 	//packet[11] = 3;						// DX3R
 
 	if (sub_protocol==DSMR)
@@ -142,7 +142,10 @@ static void __attribute__((unused)) DSM_initialize_bind_phase()
 static void __attribute__((unused)) DSM_update_channels()
 {
 	prev_option=option;
-	num_ch=option & 0x0F;				// Remove flags 0x80=max_throw, 0x40=11ms
+	num_ch=option & 0x0F;        // Remove flags 0x80=max_throw, 0x40=11ms, 0x20=Cloned
+  
+  if (num_ch==0)            // Special case for 16ch, since channels are encoded in lower 4 bits, 0=16 channels
+    num_ch=16; 
 
 	if(num_ch<3)
 		num_ch=6;						// Default to 6 channels if invalid choice...


### PR DESCRIPTION
This is an small fix after the X-Plus enhancements #1138

Small fix to support Ch16.  Since channels are encoded in 4 bits, it currently only works up to Ch15.
Treating 0 as Ch16, now allow to use CH16.

On the bind, restrict to 12ch,   one very old DSM2 10ch RX was getting confused if trying to bind with 16 channels.
All LemonRX, OrangeRX, Spektrum UMX and Spektrum recent receivers works fine.

