### PR TITLE
Fix MoFly sub-protocol mode, rate and aux switch encoding

### DIFF
--- a/Multiprotocol/XK_ccnrf.ino
+++ b/Multiprotocol/XK_ccnrf.ino
@@ -118,15 +118,15 @@ static void __attribute__((unused)) XK_send_packet()
 		memset(&packet[4],0x40,3);					// Trims centered
 		//0x00 default MM Mode
 		if(CH5_SW)
-			packet[10] = 0x02; 						// 6G Mode
+			packet[10] = 0x01; 						// 6G Mode
 		else
 			if(Channel_data[CH5] > CHANNEL_MIN_COMMAND)
-				packet[10] = 0x01; 					// 3D-Mode
-		packet[10] |= GET_FLAG(CH6_SW ,0xFC);		// Low/High rate
+				packet[10] = 0x02; 					// 3D-Mode
+		packet[10] |= GET_FLAG(CH6_SW ,0x04);		// Low/High rate
 		packet[11]  = GET_FLAG(CH7_SW ,0x10)		// Back Flip - momentary switch
 					 |GET_FLAG(CH8_SW ,0x20)		// Left Roll - momentary switch
-					 |GET_FLAG(CH9_SW ,0x40)		// Right Roll - momentary switch
-					 |GET_FLAG(CH10_SW,0x80);		// Inverted Flight - latching switch
+					 |GET_FLAG(CH9_SW ,0x04)		// Right Roll - momentary switch
+					 |GET_FLAG(CH10_SW,0x08);		// Inverted Flight - latching switch
 	}
 
 	crc=packet[0];


### PR DESCRIPTION

## Description

This PR fixes incorrect encoding values in the MoFly sub-protocol.

The current implementation uses different values from the original MoFly transmitter for flight modes, rate setting, and AUX switch functions.

The correct values were determined by capturing XN297 packets from an original MoFly transmitter and comparing the transmitted data with the current implementation.

## Changes

Corrected the following encoding values:

| Function | Old Value | New Value |
|----------|-----------|-----------|
| 6G mode | `0x02` | `0x01` |
| 3D mode | `0x01` | `0x02` |
| Rate | `0xFC` | `0x04` |
| Right roll | `0x40` | `0x04` |
| Inverted | `0x80` | `0x08` |

## Testing

The changes were tested on a real MoFly model.

Verified functions:

- 6G / 3D mode switching
- Rate switching
- Right roll AUX function
- Inverted mode AUX function

All tested functions now match the behavior of the original MoFly transmitter.

## Additional Information

The updated values are based on real XN297 packet captures from the original transmitter and have been verified with the actual model.